### PR TITLE
fix missing mapping type in signature. also intern strings #56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # LPC Language Services Changelog
 
+## 1.0.31
+
+-   Fix: [Signature hint not recognizing mapping type #56](https://github.com/jlchmura/lpc-language-server/issues/56)
+-   Intern identifiers when parsing to lower memory utilization.
+
 ## 1.0.30
 
 -   Because 1.0.29 was incomplete

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lpc",
     "displayName": "LPC",
-    "version": "1.0.30",
+    "version": "1.0.31",
     "galleryBanner": {
         "color": "#000000",
         "theme": "dark"


### PR DESCRIPTION
Fixes #56 
- Display correct string for mapping types in function signatures.

Enhancement:
- Identifier strings are now interned to reduce memory.