### PR TITLE
Memory improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,10 +11,10 @@
                 // "${workspaceRoot}/../StickLib",
                 // "${workspaceRoot}/../mg-mudlib",
                 // "${workspaceRoot}/../lima",
-                "${workspaceRoot}/../lp-245",
+                // "${workspaceRoot}/../lpc-test2",
                 // "${workspaceRoot}/../glpu-john",
                 // "${workspaceRoot}/../nightmare-residuum",
-                // "${workspaceRoot}/../infinity-lib",
+                "${workspaceRoot}/../infinity-lib",
                 // "${workspaceRoot}/../fluff-test",
                 //"${workspaceRoot}/efuns/ldmud",
                 "--extensionDevelopmentPath=${workspaceRoot}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.14
 
 -   Set default max heap size to 3072 and added the `LPC.languageServer.maxLpcServerMemory` configuration option to change.
+-   Detect and report circular `#include` references.
 
 ## 1.1.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LPC Language Services Changelog
 
+## 1.1.14
+
+-   Set default max heap size to 3072 and added the `LPC.languageServer.maxLpcServerMemory` configuration option to change.
+
 ## 1.1.13
 
 -   Fix: Project info incorrectly reported driver type as FluffOS (see [FluffOS - Maybe classes aren't being parsed properly anymore #113](https://github.com/jlchmura/lpc-language-server/issues/113))

--- a/client/src/configuration/configuration.node.ts
+++ b/client/src/configuration/configuration.node.ts
@@ -1,0 +1,3 @@
+import { BaseServiceConfigurationProvider } from "./configuration";
+
+export class NodeServiceConfigurationProvider extends BaseServiceConfigurationProvider {}

--- a/client/src/configuration/configuration.ts
+++ b/client/src/configuration/configuration.ts
@@ -1,0 +1,31 @@
+import * as vscode from 'vscode';
+
+export abstract class BaseServiceConfigurationProvider {
+    public loadFromWorkspace(): LpcServiceConfiguration {
+		const configuration = vscode.workspace.getConfiguration();
+        return {
+            locale: this.readLocale(configuration),
+            maxLpcServerMemory: this.readMaxLpcServerMemory(configuration),
+        }
+    }
+
+    protected readLocale(configuration: vscode.WorkspaceConfiguration): string | null {
+		const value = configuration.get<string>('LPC.locale', 'auto');
+		return !value || value === 'auto' ? null : value;
+	}
+
+    protected readMaxLpcServerMemory(configuration: vscode.WorkspaceConfiguration): number {
+		const defaultMaxMemory = 3072;
+		const minimumMaxMemory = 128;
+		const memoryInMB = configuration.get<number>('LPC.languageServer.maxLpcServerMemory', defaultMaxMemory);
+		if (!Number.isSafeInteger(memoryInMB)) {
+			return defaultMaxMemory;
+		}
+		return Math.max(memoryInMB, minimumMaxMemory);
+	}
+}
+
+export interface LpcServiceConfiguration {
+    readonly locale: string | null;
+    readonly maxLpcServerMemory: number;
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -25,6 +25,7 @@ import {
 import { ProgressIndicator } from "./ProgressIndicator";
 import { DocumentSelector } from "./documentSelector";
 import { LanguageDescription, isLpcConfigFileName, standardLanguageDescriptions } from "./configuration/languageDescription";
+import { NodeServiceConfigurationProvider } from "./configuration/configuration.node";
 
 let clientInitialized = false;
 let client: LanguageClient;
@@ -34,10 +35,15 @@ const _disposables: vscode.Disposable[] = [];
 let _isDisposed = false;
 
 export async function activate(context: ExtensionContext) {
+    const serviceConfigurationProvider = new NodeServiceConfigurationProvider();
+    const configuration = serviceConfigurationProvider.loadFromWorkspace();
+
     // The server is implemented in node
     const serverModule = context.asAbsolutePath(
         path.join("out", "server", "src", "server.js")
-    );    
+    );
+
+    const maxServerMemory = configuration.maxLpcServerMemory;
 
     // get location of efuns folder and pass to server as an argument
     const efunDir = context.asAbsolutePath("efuns");
@@ -57,7 +63,7 @@ export async function activate(context: ExtensionContext) {
     }
 
     let debugOptions = {
-        execArgv: ["--nolazy", "--enable-source-maps", "--inspect"]
+        execArgv: ["--nolazy", "--enable-source-maps", "--inspect", "--max-old-space-size=" + maxServerMemory]
     };
 
     const serverArgs = [efunDir, "--driverType", defaultDriverType, "--serverMode", "semantic"];
@@ -69,7 +75,7 @@ export async function activate(context: ExtensionContext) {
         run: {
             module: serverModule,
             transport: TransportKind.ipc,
-            options: { execArgv: ["--enable-source-maps"] },
+            options: { execArgv: ["--enable-source-maps", "--max-old-space-size=" + maxServerMemory] },
             args: serverArgs,
         },
         debug: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lpc",
     "displayName": "LPC",
-    "version": "1.1.13",
+    "version": "1.1.14",
     "galleryBanner": {
         "color": "#000000",
         "theme": "dark"
@@ -154,7 +154,33 @@
                     ]
                 }
             }
-        ]
+        ],
+        "configuration": {
+            "properties": {
+                "LPC.locale": {
+                    "type": "string",
+                    "default": "auto",
+                    "enum": [
+                        "auto",  
+                        "en",                      
+                        "zh-CN"
+                    ],
+                    "enumDescriptions": [
+                        "Use VS Code's configured display language",                                    
+                        "English",                                    
+                        "中文(简体)"                                    
+                    ],
+                    "markdownDescription": "Sets the locale used to report LPC errors. Defaults to use VS Code's locale.",
+                    "scope": "window"
+                },
+                "LPC.languageServer.maxLpcServerMemory": {
+                    "type": "number",
+                    "default": 3072,
+                    "description": "The maximum amount of memory (in MB) to allocate to the LPC language server process.",
+                    "scope": "window"
+                }
+            }
+        }
     },
     "keywords": [
         "LPC",

--- a/server/src/compiler/diagnosticInformation.ts
+++ b/server/src/compiler/diagnosticInformation.ts
@@ -34,6 +34,7 @@ export const Diagnostics = {
     LPCDoc_var_tags_must_be_in_their_own_LPCDoc_comment: diag(9026, DiagnosticCategory.Error, "LPCDoc_var_tags_must_be_in_their_own_LPCDoc_comment_9026", "LPCDoc @var tags must be in their own LPCDoc comment."),
     LPCDoc_var_tags_can_only_annotate_inherited_variables_0_is_a_local_variable: diag(9027, DiagnosticCategory.Error, "LPCDoc_var_tags_can_only_annotate_inherited_variables_0_is_a_local_variable_9027", "LPCDoc @var tags can only annotate inherited variables. '{0}' is a local variable."),
     LPCDoc_var_tag_should_provide_a_variable_name: diag(9028, DiagnosticCategory.Error, "LPCDoc_var_tag_should_provide_a_variable_name_9028", "LPCDoc @var tag should provide a variable name."),
+    Circular_include_detected_0_to_1: diag(9029, DiagnosticCategory.Error, "Circular_include_detected_0_to_1_9029", "Circular include detected '{0}' -> '{1}'."),
 
     // Scanner
     _0_expected: diag(1005, DiagnosticCategory.Error, "_0_expected_1005", "'{0}' expected."),    

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -15,7 +15,7 @@ const enum SignatureFlags {
     JSDoc = 1 << 5,
 }
 
-const MAX_STRING_INTERN_LEN = 8;
+const MAX_STRING_INTERN_LEN = 6;
 
 type IncludeGraph = Map<string, Set<string>>;
 

--- a/server/src/compiler/scanner.ts
+++ b/server/src/compiler/scanner.ts
@@ -1514,8 +1514,11 @@ export function createScanner(
         const quoteChar = charCodeUnchecked(pos);
         pos++;
         let result = "";
+        // const sliceStart = pos;
         let start = pos;
+        // let offset = 0;
         while (true) {
+            // offset = 0;
             if (pos >= end) {
                 result += text.substring(start, pos);
                 tokenFlags |= TokenFlags.Unterminated;
@@ -1526,6 +1529,7 @@ export function createScanner(
             if (ch === quoteChar || (quoteChar === CharacterCodes.lessThan && ch === CharacterCodes.greaterThan)) {
                 result += text.substring(start, pos);
                 pos++;
+                // offset = 1;
                 break;
             }
             if (ch === CharacterCodes.backslash && !jsxAttributeString) {
@@ -1542,8 +1546,11 @@ export function createScanner(
                 error(Diagnostics.Unterminated_string_literal);
                 break;
             }
+            // offset = 1;
             pos++;
         }
+
+        // return text.substring(sliceStart, pos - offset);        
         return result;
     }
 

--- a/server/src/lpcserver/server.ts
+++ b/server/src/lpcserver/server.ts
@@ -10,6 +10,7 @@ import { convertNavTree } from "./utils.js";
 import * as typeConverters from './typeConverters';
 import { KindModifiers } from "./protocol.const.js";
 import { CompletionEntryDetails, SignatureHelp } from "./typeConverters";
+import { getHeapStatistics } from "v8";
 
 const logger = new Logger(undefined, true, lpc.server.LogLevel.normal);
 const DIAG_DELAY = 0;
@@ -90,6 +91,9 @@ export function start(connection: Connection, platform: string, args: string[]) 
     logger.info(`Arguments: ${args.join(" ")}`);
     logger.info(`Platform: ${platform} NodeVersion: ${process.version} CaseSensitive: ${lpc.sys.useCaseSensitiveFileNames}`);
     logger.info(`ServerMode: ${serverMode}`);
+    try {
+        logger.info(`Heap Limit: ${Math.round(getHeapStatistics().heap_size_limit / 1024 / 1024)} MB`);    
+    } catch {}
 
     if (serverMode === lpc.LanguageServiceMode.Syntactic) {
         logger.info("No further log entries will be generated for syntactic server");

--- a/server/src/server/scriptInfo.ts
+++ b/server/src/server/scriptInfo.ts
@@ -1,5 +1,5 @@
 import { clear, closeFileWatcherOf, computeLineAndCharacterOfPosition, computeLineStarts, computePositionOfLineAndCharacter, contains, createTextSpanFromBounds, Debug, directorySeparator, DocumentPositionMapper, DocumentRegistryBucketKeyWithMode, FileWatcher, FileWatcherEventKind, forEach, FormatCodeSettings, getBaseFileName, getLineInfo, getSnapshotText, hasLPCFileExtension, IScriptSnapshot, isString, LineInfo, missingFileModifiedTime, orderedRemoveItem, Path, ScriptKind, ScriptSnapshot, some, SourceFile, SourceFileLike, TextSpan, UserPreferences } from "./_namespaces/lpc";
-import { AbsolutePositionAndLineText, ConfiguredProject, Errors, isBackgroundProject, isConfiguredProject, isInferredProject, isProjectDeferredClose, maxFileSize, NormalizedPath, Project, protocol, ScriptVersionCache, ServerHost } from "./_namespaces/lpc.server";
+import { AbsolutePositionAndLineText, Errors, isBackgroundProject, isConfiguredProject, isInferredProject, isProjectDeferredClose, maxFileSize, NormalizedPath, Project, protocol, ScriptVersionCache, ServerHost } from "./_namespaces/lpc.server";
 
 /** @internal */
 export class TextStorage {


### PR DESCRIPTION
The server will now run with a default max heap size of 3072.  The user can change this using the `LPC.languageServer.maxLpcServerMemory` setting in vscode preferences.

This change was made to address #121 