### PR TITLE
Prefer override with LPCDoc comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.18
 
 -   Fix: [Diagnostics are duplicated after running the build task #137](https://github.com/jlchmura/lpc-language-server/issues/137)
+-   Fix: [Incorrect signature resolution when function decl does not have doc comment #139](https://github.com/jlchmura/lpc-language-server/issues/139)  
 -   Added `.h` to the file extensions that will activate the language server.
 
 ## 1.1.17

--- a/build.mjs
+++ b/build.mjs
@@ -8,7 +8,7 @@ await esbuild.build({
   platform: 'node',
   format: 'cjs',
   sourcemap: 'linked',
-  treeShaking: true,
-  minify: true,
+  // treeShaking: true,
+  // minify: true,
   mainFields: ['module', 'main'],  //  needed for jsonc-parse until they fix https://github.com/microsoft/node-jsonc-parser/issues/57
 });

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -4599,6 +4599,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 flags |= SignatureFlags.IsVarArgs;
             }
 
+            if (hasJSDocNodes(declaration)) {
+                flags |= SignatureFlags.HasJsDoc;
+            }
+
             // If this is a JSDoc construct signature, then skip the first parameter in the
             // parameter list.  The first parameter represents the return type of the construct
             // signature.
@@ -31797,7 +31801,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             // specialized signatures always need to be placed before non-specialized signatures regardless
             // of the cutoff position; see GH#1133
-            if (signatureHasLiteralTypes(signature)) {
+            if (signatureHasLiteralTypes(signature) || signatureHasJsDoc(signature)) {
                 specializedIndex++;
                 spliceIndex = specializedIndex;
                 // The cutoff index always needs to be greater than or equal to the specialized signature index
@@ -34404,4 +34408,8 @@ const typeofNEFacts: ReadonlyMap<string, TypeFacts> = new Map(Object.entries({
 
 function signatureHasLiteralTypes(s: Signature) {
     return !!(s.flags & SignatureFlags.HasLiteralTypes);
+}
+
+function signatureHasJsDoc(s: Signature) {
+    return !!(s.flags & SignatureFlags.HasJsDoc);
 }

--- a/server/src/compiler/types.ts
+++ b/server/src/compiler/types.ts
@@ -4078,6 +4078,7 @@ export const enum SignatureFlags {
     HasLiteralTypes = 1 << 1,           // Indicates signature is specialized
     Abstract = 1 << 2,                  // Indicates signature comes from an abstract class, abstract construct signature, or abstract constructor type
     IsVarArgs = 1 << 3,                 // Indicates signature is a varargs signature
+    HasJsDoc = 1 << 4,                  // Indicates signature's declaration has JSDoc comments
 
     // Non-propagating flags
     IsInnerCallChain = 1 << 6,          // Indicates signature comes from a CallChain nested in an outer OptionalChain


### PR DESCRIPTION
This PR modifies signature resolution to prefer an override with LPCDoc.  If both the function and forward define have a doc comment, this function will be prefered.