### PR TITLE
Add sefun inherited members to globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Fix: [Diagnostics are duplicated after running the build task #137](https://github.com/jlchmura/lpc-language-server/issues/137)
 -   Fix: [LPCDoc comment should not be captured by #include #140](https://github.com/jlchmura/lpc-language-server/issues/140)
 -   Fix: [Incorrect signature resolution when function decl does not have doc comment #139](https://github.com/jlchmura/lpc-language-server/issues/139)
+-   Fix: [Type predicates not working in inherited sefun files. #144](https://github.com/jlchmura/lpc-language-server/issues/144)
 -   Fix: [Fix typings for filter efun and add unit test, closes #145](https://github.com/jlchmura/lpc-language-server/issues/145)
 -   Added `.h` to the file extensions that will activate the language server.
 

--- a/server/src/compiler/utilities.ts
+++ b/server/src/compiler/utilities.ts
@@ -1312,7 +1312,7 @@ export function createNameResolver({
                         }
                     }
                                          
-                    // now check inherited symbols
+                    // now check inherited symbols                    
                     const importTypes = sourceFileSymbol.inherits;                                        
                     const importStack = Array.from(importTypes?.entries() ?? emptyArray);
                     const seenImports = new Set<string>();                    
@@ -1332,16 +1332,9 @@ export function createNameResolver({
                         if (result) {
                             break loop;
                         }
-
-                        // TODO: filter by import prefix here                            
-                        const inheritFile = first(importType.symbol.declarations);                                                                                                                        
-                        const inheritFileSymbol = getSymbolOfDeclaration(inheritFile);                        
-                        const nestedInherits = inheritFileSymbol.inherits;
-                        importStack.push(...(nestedInherits?.entries() ?? emptyArray));
-                        // if (nestedInherits) {
-
-                        //     forEachEntry(nestedInherits, (importSymbol, importSymbolName) => { importTypes.set(importSymbolName, importSymbol); });                     
-                        // }                                                
+                        
+                        const nestedInherits = importType?.symbol?.inherits;
+                        importStack.push(...(nestedInherits?.entries() ?? emptyArray));                                                  
                     }
                                        
                     //const moduleExports = getSymbolOfDeclaration(location as SourceFile /*| ModuleDeclaration*/)?.exports || emptySymbols;                    

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -263,6 +263,12 @@ exports[`Compiler compiler/include1.c Reports correct errors for compiler/includ
 
 exports[`Compiler compiler/indexAccess.c Reports correct errors for compiler/indexAccess.c: diags-compiler/indexAccess.c 1`] = `""`;
 
+exports[`Compiler compiler/inherit1.base1.c Reports correct errors for compiler/inherit1.base1.c: diags-compiler/inherit1.base1.c 1`] = `""`;
+
+exports[`Compiler compiler/inherit1.base2.c Reports correct errors for compiler/inherit1.base2.c: diags-compiler/inherit1.base2.c 1`] = `""`;
+
+exports[`Compiler compiler/inherit1.c Reports correct errors for compiler/inherit1.c: diags-compiler/inherit1.c 1`] = `""`;
+
 exports[`Compiler compiler/intLiteral1.c Reports correct errors for compiler/intLiteral1.c: diags-compiler/intLiteral1.c 1`] = `""`;
 
 exports[`Compiler compiler/intLiteral2.c Reports correct errors for compiler/intLiteral2.c: diags-compiler/intLiteral2.c 1`] = `""`;

--- a/server/src/tests/cases/compiler/inherit1.base1.c
+++ b/server/src/tests/cases/compiler/inherit1.base1.c
@@ -1,0 +1,7 @@
+
+inherit "inherit1.base2.c";
+
+string query_name() {
+    isBase2();
+    return "inherit1.base1";
+}

--- a/server/src/tests/cases/compiler/inherit1.base2.c
+++ b/server/src/tests/cases/compiler/inherit1.base2.c
@@ -1,0 +1,8 @@
+
+string query_name() {
+   return "inherit1.base2";
+}
+
+int isBase2() {
+   return 1;
+}

--- a/server/src/tests/cases/compiler/inherit1.c
+++ b/server/src/tests/cases/compiler/inherit1.c
@@ -1,0 +1,10 @@
+inherit "inherit1.base1.c";
+
+// make sure members from nested inherits are resolved correctly 
+
+test() {
+    // base2 comes from base1->base2
+    int id = isBase2();
+    // query_name is defined in both base1 & base2
+    string name = query_name();    
+}


### PR DESCRIPTION
This PR fixes a problem where sefun inherited members were not being added to the globals table. This caused them to be inconsistently resolved.

This PR closes #144.