### PR TITLE
Trigger re-parse of files that include the file being edited.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Fix: [Diagnostics are duplicated after running the build task #137](https://github.com/jlchmura/lpc-language-server/issues/137)
 -   Fix: [LPCDoc comment should not be captured by #include #140](https://github.com/jlchmura/lpc-language-server/issues/140)
 -   Fix: [Incorrect signature resolution when function decl does not have doc comment #139](https://github.com/jlchmura/lpc-language-server/issues/139)
+-   Fix: [Editing an .h file should trigger a reparse of files that include it. #143](https://github.com/jlchmura/lpc-language-server/issues/143)
 -   Fix: [Type predicates not working in inherited sefun files. #144](https://github.com/jlchmura/lpc-language-server/issues/144)
 -   Fix: [Fix typings for filter efun and add unit test, closes #145](https://github.com/jlchmura/lpc-language-server/issues/145)
 -   Added `.h` to the file extensions that will activate the language server.

--- a/server/src/server/editorServices.ts
+++ b/server/src/server/editorServices.ts
@@ -2623,6 +2623,7 @@ export class ProjectService {
 
     /** @internal */
     applyChangesToFile(scriptInfo: ScriptInfo, changes: Iterable<TextChange>) {
+        
         for (const change of changes) {            
             scriptInfo.editContent(change.span.start, change.span.start + change.span.length, change.newText);
         }

--- a/server/src/server/project.ts
+++ b/server/src/server/project.ts
@@ -1,5 +1,5 @@
 import * as lpc from "./_namespaces/lpc.js";
-import { addRange, append, arrayFrom, CachedDirectoryStructureHost, clearMap, closeFileWatcher, combinePaths, CompilerHost, CompilerOptions, createCacheableExportInfoMap, createLanguageService, createLpcFileHandler, createResolutionCache, Debug, Diagnostic, DirectoryStructureHost, DirectoryWatcherCallback, DocumentRegistry, explainFiles, ExportInfoMap, FileWatcher, FileWatcherCallback, FileWatcherEventKind, filter, flatMap, forEach, forEachKey, GetCanonicalFileName, getDefaultLibFileName, getDefaultLibFolder, getDirectoryPath, getNormalizedAbsolutePath, getOrUpdate, HasInvalidatedLibResolutions, HasInvalidatedResolutions, IScriptSnapshot, isExternalModuleNameRelative, isString, JSDocParsingMode, LanguageService, LanguageServiceHost, LanguageServiceMode, maybeBind, ModuleResolutionHost, noopFileWatcher, normalizePath, ParsedCommandLine, parsePackageName, Path, PerformanceEvent, PollingInterval, Program, ProgramUpdateLevel, ProjectReference, ResolutionCache, resolutionExtensionIsTSOrJson, ResolvedModuleWithFailedLookupLocations, ResolvedProjectReference, returnFalse, returnTrue, sortAndDeduplicate, SortedReadonlyArray, SourceFile, SourceMapper, StringLiteralLike, StructureIsReused, ThrottledCancellationToken, timestamp, toPath, tracing, tryGetLocalizedLibPath, TypeAcquisition, updateErrorForNoInputFiles, updateMissingFilePathsWatch, WatchDirectoryFlags, WatchOptions, WatchType } from "./_namespaces/lpc.js";
+import { addRange, append, arrayFrom, CachedDirectoryStructureHost, clearMap, closeFileWatcher, combinePaths, CompilerHost, CompilerOptions, createCacheableExportInfoMap, createLanguageService, createLpcFileHandler, createResolutionCache, Debug, Diagnostic, DirectoryStructureHost, DirectoryWatcherCallback, DocumentRegistry, explainFiles, ExportInfoMap, FileWatcher, FileWatcherCallback, FileWatcherEventKind, filter, flatMap, forEach, forEachKey, GetCanonicalFileName, getDefaultLibFileName, getDefaultLibFolder, getDirectoryPath, getNormalizedAbsolutePath, getOrUpdate, HasInvalidatedLibResolutions, HasInvalidatedResolutions, IScriptSnapshot, isExternalModuleNameRelative, isString, JSDocParsingMode, LanguageService, LanguageServiceHost, LanguageServiceMode, maybeBind, ModuleResolutionCache, ModuleResolutionHost, noopFileWatcher, normalizePath, ParsedCommandLine, parsePackageName, Path, PerformanceEvent, PollingInterval, Program, ProgramUpdateLevel, ProjectReference, ResolutionCache, resolutionExtensionIsTSOrJson, ResolvedModuleWithFailedLookupLocations, ResolvedProjectReference, returnFalse, returnTrue, sortAndDeduplicate, SortedReadonlyArray, SourceFile, SourceMapper, StringLiteralLike, StructureIsReused, ThrottledCancellationToken, timestamp, toPath, tracing, tryGetLocalizedLibPath, TypeAcquisition, updateErrorForNoInputFiles, updateMissingFilePathsWatch, WatchDirectoryFlags, WatchOptions, WatchType } from "./_namespaces/lpc.js";
 import { asNormalizedPath, emptyArray, Errors, HostCancellationToken, LogLevel, NormalizedPath, ProjectService, ScriptInfo, updateProjectIfDirty } from "./_namespaces/lpc.server.js";
 
 
@@ -193,6 +193,11 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     /** @internal */
     resolveModuleNameLiterals(moduleLiterals: readonly StringLiteralLike[], containingFile: string, redirectedReference: ResolvedProjectReference | undefined, options: CompilerOptions, containingSourceFile: SourceFile, reusedNames: readonly StringLiteralLike[] | undefined): readonly ResolvedModuleWithFailedLookupLocations[] {
         return this.resolutionCache.resolveModuleNameLiterals(moduleLiterals, containingFile, redirectedReference, options, containingSourceFile, reusedNames);
+    }
+
+    /** @internal */
+    getModuleResolutionCache(): ModuleResolutionCache | undefined {
+        return this.resolutionCache.getModuleResolutionCache();
     }
     
     disableLanguageService(lastFileExceededProgramSize?: string) {
@@ -830,6 +835,8 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
         return this.getCurrentProgram()?.forEachResolvedProjectReference(cb);
     }
 
+    
+    
     private updateGraphWorker() {
         const oldProgram = this.languageService.getCurrentProgram();
         Debug.assert(oldProgram === this.program);

--- a/server/src/services/services.ts
+++ b/server/src/services/services.ts
@@ -1668,10 +1668,10 @@ export function createLanguageService(
             //hasChangedAutomaticTypeDirectiveNames,
             trace: maybeBind(host, host.trace),
             resolveModuleNames: maybeBind(host, host.resolveModuleNames),
-            // getModuleResolutionCache: maybeBind(
-            //     host,
-            //     host.getModuleResolutionCache
-            // ),
+            getModuleResolutionCache: maybeBind(
+                host,
+                host.getModuleResolutionCache
+            ),
             createHash: maybeBind(host, host.createHash),
             // resolveTypeReferenceDirectives: maybeBind(
             //     host,

--- a/server/src/services/types.ts
+++ b/server/src/services/types.ts
@@ -15,6 +15,8 @@ import {
     LineAndCharacter,
     LpcFileHandler,
     MinimalResolutionCacheHost,
+    ModuleResolutionCache,
+    ModuleSpecifierCache,
     Node,
     ParsedCommandLine,
     Program,
@@ -649,7 +651,7 @@ export interface LanguageServiceHost
     /** @internal */ getGlobalTypingsCacheLocation?(): string | undefined;
     // /** @internal */ getSymlinkCache?(files?: readonly SourceFile[]): SymlinkCache;
     /* Lets the Program from a AutoImportProviderProject use its host project's ModuleResolutionCache */
-    // /** @internal */ getModuleResolutionCache?(): ModuleResolutionCache | undefined;
+    /** @internal */ getModuleResolutionCache?(): ModuleResolutionCache | undefined;
 
     /*
      * Required for full import and type reference completions.
@@ -676,7 +678,7 @@ export interface LanguageServiceHost
     ): string | undefined;
     // /** @internal */ getPackageJsonsForAutoImport?(rootDir?: string): readonly ProjectPackageJsonInfo[];
     /** @internal */ getCachedExportInfoMap?(): ExportInfoMap;
-    // /** @internal */ getModuleSpecifierCache?(): ModuleSpecifierCache;
+    /** @internal */ getModuleSpecifierCache?(): ModuleSpecifierCache;
     /** @internal */ setCompilerHost?(host: CompilerHost): void;
     /** @internal */ useSourceOfProjectReferenceRedirect?(): boolean;
     /** @internal */ getPackageJsonAutoImportProvider?(): Program | undefined;


### PR DESCRIPTION
This PR does two things to close #143 :
1) Enables the resolution cache, which wasn't being used before.
2) Uses the data in the resolution cache to find files that are dependent on a source file.  This information is used to trigger a re-parse of those files. Currently this only happens when editing an `.h` file.