### PR TITLE
Allow comma expr inside index access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # LPC Language Services Changelog
 
+## 1.1.19
+
+-   Fix: [Parser error on mapping access with multi args inside a prefix unary expr #150](https://github.com/jlchmura/lpc-language-server/issues/150)
+-   Fix: Node position incorrect when parsing a macro inside a nested include directive.
+
 ## 1.1.18
 
 -   Fix: [Diagnostics are duplicated after running the build task #137](https://github.com/jlchmura/lpc-language-server/issues/137)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lpc",
     "displayName": "LPC",
-    "version": "1.1.18",
+    "version": "1.1.19",
     "galleryBanner": {
         "color": "#000000",
         "theme": "dark"

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -32862,6 +32862,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         else if (args.length) {
             // too long; error goes on the excess parameters
             const errorSpan = factory.createNodeArray(args.slice(max));
+            const errorSourceFile = getSourceFileOrIncludeOfNode(first(errorSpan));
             const pos = first(errorSpan).pos;
             let end = last(errorSpan).end;
             if (end === pos) {
@@ -32871,9 +32872,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (headMessage) {
                 let chain = chainDiagnosticMessages(/*details*/ undefined, error, parameterRange, args.length);
                 chain = chainDiagnosticMessages(chain, headMessage);
-                return createDiagnosticForNodeArrayFromMessageChain(getSourceFileOrIncludeOfNode(node), errorSpan, chain);
+                return createDiagnosticForNodeArrayFromMessageChain(errorSourceFile, errorSpan, chain);
             }
-            return createDiagnosticForNodeArray(getSourceFileOrIncludeOfNode(node), errorSpan, error, parameterRange, args.length);
+            return createDiagnosticForNodeArray(errorSourceFile, errorSpan, error, parameterRange, args.length);
         }
     }
 

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -4317,26 +4317,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // The include sourcefile is no longer needed, because the include node acts
         // as a sourcefile itself.  However, if we ever did need it - the better way to
         // acomplish this would be to add it to NodeLinks
-
-        // else if (!node.resolvedSourceFile) {
-        //     // try to resolve the source file for this include
-        //     // this may be a horrible idea
-        //     // TODO - assess the perf impact of this
-        //     // It is used in utilities/createDiagnosticForNode()
-
-        //     // create a fake string literal w/ the include filename
-        //     const stringLiteral = factory.createStringLiteral(node.fileName);
-        //     setTextRangePosEnd(stringLiteral, node.content.pos, node.content.end);
-
-        //     //store sourcefile on links?            
-        //     const module = resolveExternalModuleName(node, stringLiteral, stringType);
-        //     if (module) {
-        //         // this should go on nodelinks, but we won't have access to that in utilities
-        //         const sourceFile = cast(first(module.declarations), isSourceFile);
-        //         node.resolvedSourceFile = sourceFile;
-        //     }
-        // }
-
+       
         forEach(node.statements, checkSourceElement);
         checkSourceElement(node.endOfFileToken);        
     }

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -2421,7 +2421,7 @@ export namespace LpcParser {
                 nodeMacroMap.set(node, rootMacro.name);                
             }
 
-            if (macroState && macroState.fileName === fileName) {
+            if (macroState) {
                 // use the macro end pos, if we're in a macro
                 const currentState = getPositionState();
                 const endToUse = Math.max((currentState.fileName === fileName && !currentState.macro) ? currentState.pos : 0, rootMacro.end);

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -2649,6 +2649,10 @@ export namespace LpcParser {
         return doOutsideOfContext(NodeFlags.DisallowInContext, func);
     }
 
+    function allowCommaInAnd<T>(func: () => T): T {
+        return doOutsideOfContext(NodeFlags.DisallowCommaContext | NodeFlags.DisallowInContext, func);
+    }
+
     function disallowInAnd<T>(func: () => T): T {
         return doInsideOfContext(NodeFlags.DisallowInContext, func);
     }
@@ -4866,13 +4870,13 @@ export namespace LpcParser {
             // let leftOp: Token<SyntaxKind.LessThanToken> | undefined, rightOp: Token<SyntaxKind.LessThanToken> | undefined;                        
             if (parseOptional(SyntaxKind.DotDotToken)) {
                 // rightOp = parseOptionalToken(SyntaxKind.LessThanToken);
-                right = allowInAnd(parseExpression);
+                right = allowCommaInAnd(parseExpression);
             } else {
                 // leftOp = parseOptionalToken(SyntaxKind.LessThanToken);
-                left = allowInAnd(parseExpression);
+                left = allowCommaInAnd(parseExpression);
                 if (parseOptional(SyntaxKind.DotDotToken) && token() !== SyntaxKind.CloseBracketToken) {
                     // leftOp = parseOptionalToken(SyntaxKind.LessThanToken);
-                    right = allowInAnd(parseExpression);
+                    right = allowCommaInAnd(parseExpression);
                 }
             }
             

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -263,6 +263,8 @@ exports[`Compiler compiler/include1.c Reports correct errors for compiler/includ
 
 exports[`Compiler compiler/indexAccess.c Reports correct errors for compiler/indexAccess.c: diags-compiler/indexAccess.c 1`] = `""`;
 
+exports[`Compiler compiler/indexAccess2.c Reports correct errors for compiler/indexAccess2.c: diags-compiler/indexAccess2.c 1`] = `""`;
+
 exports[`Compiler compiler/inherit1.base1.c Reports correct errors for compiler/inherit1.base1.c: diags-compiler/inherit1.base1.c 1`] = `""`;
 
 exports[`Compiler compiler/inherit1.base2.c Reports correct errors for compiler/inherit1.base2.c: diags-compiler/inherit1.base2.c 1`] = `""`;

--- a/server/src/tests/cases/compiler/indexAccess2.c
+++ b/server/src/tests/cases/compiler/indexAccess2.c
@@ -1,0 +1,14 @@
+
+mapping m = ([ ]);
+
+test() {        
+    string foo, bar;    
+    if (!m[foo, bar]) {
+
+    }
+} 
+
+/** 
+ * multi-arg mapping access inside a prefix unary expression
+ * should not error
+ */


### PR DESCRIPTION
When parsing an index access inside another expression that has disallowed commas (such as a prefix unary), the parser needs to run outside the DisallowComma context for index access so that it can properly parse its comma expression.