### PR TITLE
update fluffos efun::present for optional second parameter

### DIFF
--- a/efuns/fluffos/objects.h
+++ b/efuns/fluffos/objects.h
@@ -132,7 +132,7 @@ varargs int query_heart_beat( object );
  * able.  returns 0
  *
  */
-object present( mixed str, object ob );
+varargs object present( mixed str, object ob );
 
 /**
  * objects - return an array of all loaded objects

--- a/efuns/fluffos/zh-cn/objects.zh-cn.h
+++ b/efuns/fluffos/zh-cn/objects.zh-cn.h
@@ -92,7 +92,7 @@ varargs int query_heart_beat( object );
  * 如果对象是隐藏的（通过 set_hide()），并且当前对象不可隐藏，则返回 0。
  *
  */
-object present( mixed str, object ob );
+varargs object present( mixed str, object ob );
 
 /**
  * objects - 返回所有加载对象的数组


### PR DESCRIPTION
Update fluffos efun::present definition for the optional second parameter. If not provided, it defaults to `this_object()`, per the efun docs:
```c
 * if  first  argument  is  object, second argument is missing, check if
 * object is in this object's inventory, or as a sibling in this  object's
 * environment's inventory, returns object's parent.
```

![image](https://github.com/user-attachments/assets/cf44c5f3-b84a-43bc-a62a-72c808f470dd)
