### PR TITLE
Use proper array element type in foreach statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LPC Language Services Changelog
 
+## 1.1.21
+
+-   Fix: [Foreach over an array always results in a string type #161](https://github.com/jlchmura/lpc-language-server/issues/161)
+
 ## 1.1.20
 
 -   Fix: [FluffOS `ref` keyword not being parsed correctly. #155](https://github.com/jlchmura/lpc-language-server/issues/155)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lpc",
     "displayName": "LPC",
-    "version": "1.1.20",
+    "version": "1.1.21",
     "galleryBanner": {
         "color": "#000000",
         "theme": "dark"

--- a/server/src/compiler/binder.ts
+++ b/server/src/compiler/binder.ts
@@ -632,11 +632,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             // case SyntaxKind.CallSignature:
             // case SyntaxKind.ConstructSignature:
             case SyntaxKind.IndexSignature:
-                return declareSymbolAndAddToSymbolTable(node as Declaration, SymbolFlags.Signature, SymbolFlags.None);
-            case SyntaxKind.TypeLiteral:
-            case SyntaxKind.JSDocTypeLiteral:
-            case SyntaxKind.MappedType:
-                return bindAnonymousTypeWorker(node as TypeLiteralNode/* | MappedTypeNode*/ | JSDocTypeLiteral);            
+                return declareSymbolAndAddToSymbolTable(node as Declaration, SymbolFlags.Signature, SymbolFlags.None);            
             case SyntaxKind.JSDocClassTag:
                 return bindJSDocClassTag(node as JSDocClassTag);
             case SyntaxKind.FunctionType:

--- a/server/src/compiler/emitter.ts
+++ b/server/src/compiler/emitter.ts
@@ -1056,9 +1056,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 case SyntaxKind.Identifier:
                     return emitIdentifier(node as Identifier);
                 case SyntaxKind.TypeLiteral:
-                    return emitTypeLiteral(node as TypeLiteralNode);
-                case SyntaxKind.ArrayType:
-                    return emitArrayType(node as ArrayTypeNode);
+                    return emitTypeLiteral(node as TypeLiteralNode);                
                 case SyntaxKind.VariableStatement:
                     return emitVariableStatement(node as VariableStatement);
                 case SyntaxKind.Parameter:

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -3089,8 +3089,7 @@ export namespace LpcParser {
             case SyntaxKind.CharLiteral:
             case SyntaxKind.FloatLiteral:
             case SyntaxKind.TrueKeyword:
-            case SyntaxKind.FalseKeyword:
-            case SyntaxKind.ObjectKeyword:
+            case SyntaxKind.FalseKeyword:            
             case SyntaxKind.AsteriskToken:
             case SyntaxKind.QuestionToken:
             case SyntaxKind.ExclamationToken:
@@ -3135,8 +3134,7 @@ export namespace LpcParser {
             case SyntaxKind.MixedKeyword:
             case SyntaxKind.MappingKeyword:
             case SyntaxKind.ObjectKeyword:
-            case SyntaxKind.UndefinedKeyword:            
-            case SyntaxKind.ObjectKeyword:            
+            case SyntaxKind.UndefinedKeyword:                                 
                 // If these are followed by a dot, then parse these out as a dotted type reference instead.
                 return parseKeywordAndNoDot();
             case SyntaxKind.StatusKeyword:     

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -256,6 +256,10 @@ Found 1 error in server/src/tests/cases/compiler/forEach6.c[90m:4[0m
 
 exports[`Compiler compiler/forEach7.c Reports correct errors for compiler/forEach7.c: diags-compiler/forEach7.c 1`] = `""`;
 
+exports[`Compiler compiler/forEach8.c Reports correct errors for compiler/forEach8.c: diags-compiler/forEach8.c 1`] = `""`;
+
+exports[`Compiler compiler/forEach9.c Reports correct errors for compiler/forEach9.c: diags-compiler/forEach9.c 1`] = `""`;
+
 exports[`Compiler compiler/forEachRef.c Reports correct errors for compiler/forEachRef.c: diags-compiler/forEachRef.c 1`] = `""`;
 
 exports[`Compiler compiler/funcDecl1.c Reports correct errors for compiler/funcDecl1.c: diags-compiler/funcDecl1.c 1`] = `""`;

--- a/server/src/tests/cases/compiler/forEach8.c
+++ b/server/src/tests/cases/compiler/forEach8.c
@@ -1,0 +1,10 @@
+test() {
+    /** @type {"object.c"*} */
+    object* arr = ({});    
+    object ob;
+    foreach(ob in arr) {
+        ob->query_number();
+    }
+}
+
+// @files object.c

--- a/server/src/tests/cases/compiler/forEach9.c
+++ b/server/src/tests/cases/compiler/forEach9.c
@@ -1,0 +1,9 @@
+test() {
+    /** @type {"object.c"*} */
+    object* arr = ({});        
+    foreach(object ob in arr) {
+        ob->query_number();
+    }
+}
+
+// @files object.c


### PR DESCRIPTION
Fixes #161 where the iterator type in a foreach was always being assigned a string even though it should have been a resolved object.