### PR TITLE
Fix type discrimination of related types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.1.22
 
+-   Fix: [objectp should maintain typed object #168](https://github.com/jlchmura/lpc-language-server/issues/168)
+-   Fix: [arrayp sefun is not changing the flow type to array #171](https://github.com/jlchmura/lpc-language-server/issues/171)
 -   Added support for LPCDoc intersection types
 
 ## 1.1.21

--- a/efuns/fluffos/arrays.h
+++ b/efuns/fluffos/arrays.h
@@ -180,12 +180,12 @@ mixed element_of(mixed *arr);
  * arrayp() - identifies whether a given variable is an array
  *
  * Returns 1 if 'arg' is an array, otherwise returns 0.
- *
+ * 
+ * @param {mixed} arg The argument to check
+ * @returns {arg is mixed*} 1 if 'arg' is an array, otherwise returns 0.
+ * @example
  * int is_array = arrayp( ({ 1, 2, 3, 4 }) ); // 1
- * int is_array = arrayp( "Foo" ); // 0 
- * @template T
- * @param {T} arg
- * @returns {arg is T*} 1 if 'arg' is an array, otherwise returns 0.
+ * int is_array = arrayp( "Foo" ); // 0  
  */
 int arrayp( mixed arg );
 

--- a/efuns/fluffos/arrays.h
+++ b/efuns/fluffos/arrays.h
@@ -183,6 +183,9 @@ mixed element_of(mixed *arr);
  *
  * int is_array = arrayp( ({ 1, 2, 3, 4 }) ); // 1
  * int is_array = arrayp( "Foo" ); // 0 
+ * @template T
+ * @param {T} arg
+ * @returns {arg is T*} 1 if 'arg' is an array, otherwise returns 0.
  */
 int arrayp( mixed arg );
 

--- a/efuns/fluffos/zh-cn/arrays.zh-cn.h
+++ b/efuns/fluffos/zh-cn/arrays.zh-cn.h
@@ -146,6 +146,9 @@ mixed element_of(mixed *arr);
  *
  * 如果'arg'是数组，则返回1，否则返回0。
  *
+ * @param {mixed} arg 要检查的参数
+ * @returns {arg is mixed*} 如果'arg'是数组，则返回1，否则返回0。
+ * @example
  * int is_array = arrayp( ({ 1, 2, 3, 4 }) ); // 1
  * int is_array = arrayp( "Foo" ); // 0 
  */

--- a/efuns/fluffos/zh-cn/objects.zh-cn.h
+++ b/efuns/fluffos/zh-cn/objects.zh-cn.h
@@ -111,6 +111,7 @@ object *objects( void | string | function func );
  *
  * @返回 {arg 是对象} 如果 'arg' 是对象则返回 1。
  *
+ * @returns {arg is object} 1 if 'arg' is an object.
  */
 int objectp( mixed arg );
 

--- a/efuns/ldmud/efun.h
+++ b/efuns/ldmud/efun.h
@@ -3967,8 +3967,8 @@ float pow(int|float base, int|float exp);
  * pointerp
  *
  * Return 1 if arg is a pointer, i.e. an array.
- * @template T
- * @returns {arg is T*} 
+ *
+ * @returns {arg is mixed*} 
  */
 int pointerp(mixed arg);
 

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -30676,9 +30676,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const matching = discriminant && getConstituentTypeForKeyType(type as UnionType, discriminant);
 
                 // in LPC - skip the directlyRelated checks if there is no discriminant.
-                if (!discriminant && !strickObjectTypes) {
-                    return candidate;
-                }
+                // if (!discriminant && !strickObjectTypes) {
+                //     return candidate;
+                // }
 
                 // For each constituent t in the current type, if t and and c are directly related, pick the most
                 // specific of the two. When t and c are related in both directions, we prefer c for type predicates
@@ -30745,13 +30745,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (!isMatchingReference(reference, expr) && inlineLevel < 5) {
                         const symbol = getResolvedSymbol(expr as Identifier);
                         // if (isConstantVariable(symbol)) {
-                        //     const declaration = symbol.valueDeclaration;
-                        //     if (declaration && isVariableDeclaration(declaration) && !declaration.type && declaration.initializer && isConstantReference(reference)) {
-                        //         inlineLevel++;
-                        //         const result = narrowType(type, declaration.initializer, assumeTrue);
-                        //         inlineLevel--;
-                        //         return result;
-                        //     }
+                            const declaration = symbol.valueDeclaration;
+                            if (declaration && isVariableDeclaration(declaration) && !declaration.type && declaration.initializer /*&& isConstantReference(reference)*/) {
+                                inlineLevel++;
+                                const result = narrowType(type, declaration.initializer, assumeTrue);
+                                inlineLevel--;
+                                return result;
+                            }
                         // }
                     }
                     // falls through


### PR DESCRIPTION
This PR fixes issues #171 and #168.
In addition, it improves the typings for the fluffos `arrayp` efun.