### PR TITLE
update fluffos efun::query_num for optional second parameter

### DIFF
--- a/efuns/fluffos/contrib.h
+++ b/efuns/fluffos/contrib.h
@@ -323,7 +323,7 @@ string query_replaced_program(void | object);
  * @param {int} num - number to convert
  * @param {int} many - (optional) defaults to 0
  */
-string query_num(int num, int many);
+varargs string query_num(int num, int many);
 
 /**
  * query_notify_fail

--- a/efuns/fluffos/zh-cn/contrib.zh-cn.h
+++ b/efuns/fluffos/zh-cn/contrib.zh-cn.h
@@ -311,7 +311,7 @@ string query_replaced_program(void | object);
  * @param {int} num - 要转换的数字
  * @param {int} many - （可选）默认为 0
  */
-string query_num(int num, int many);
+varargs string query_num(int num, int many);
 
 /**
  * query_notify_fail


### PR DESCRIPTION
Update fluffos efun::query_num definition for the optional second parameter. If not provided, it defaults to 0.

```
string query_num(int num, int many: 0);



Converts `num` into a string representation. If `many` is greater than 0
and `num` is greater than `many`, the resulting string is "many".

Any `num` greater than 99,999 is always "many", the same for any `num` less
than 0.
```