### PR TITLE
update fluffos efun::shutdown for optional parameter

### DIFF
--- a/efuns/fluffos/system.h
+++ b/efuns/fluffos/system.h
@@ -113,7 +113,7 @@ string strftime( string fmt, int time );
  * valid_override(4) up (in master.c) to protect against efun::shutdown().
  *
  */
-void shutdown( int how );
+varargs void shutdown( int how );
 
 /**
  * set_reset - modify the time until reset on an object

--- a/efuns/fluffos/zh-cn/system.zh-cn.h
+++ b/efuns/fluffos/zh-cn/system.zh-cn.h
@@ -99,7 +99,7 @@ string strftime( string fmt, int time );
  * 确保在master.c中设置valid_override(4)以保护against efun::shutdown()。
  *
  */
-void shutdown( int how );
+varargs void shutdown( int how );
 
 /**
  * set_reset - 修改对象的重置时间


### PR DESCRIPTION
Update fluffos::shutdown definition for the optional parameter. If not provided, it defaults to `0`.