### PR TITLE
Parse directives that end with EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.24
 
 -   Fix: [Adjust handling of array of arrays #180](https://github.com/jlchmura/lpc-language-server/issues/180)
+-   Fix: [Parser errors when last last is an include directive without a newline #184](https://github.com/jlchmura/lpc-language-server/issues/184)
 -   Fix: Import will null text can crash program file load
 -   Improved efun definitions:
     -   FluffOS [`shutdown`](https://github.com/jlchmura/lpc-language-server/pull/182)

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -1845,6 +1845,15 @@ export namespace LpcParser {
         return withJSDoc(finishNode(factory.createEmptyStatement(), pos), hasJSDoc);
     }
 
+    function parseValidDirectiveEnd() {
+        if (token() == SyntaxKind.NewLineTrivia || token() == SyntaxKind.EndOfFileToken) {
+            return true;
+        } else {
+            parseErrorAtCurrentToken(Diagnostics.Expected_newline_after_directive);
+            return false;
+        }            
+    }
+
     function parseDirective(): PreprocessorDirective {
         scanner.setReportLineBreak(true);
 
@@ -1873,8 +1882,8 @@ export namespace LpcParser {
                     nextToken();            
                 }
         }
-
-        let scanNextToken = parseExpected(SyntaxKind.NewLineTrivia, Diagnostics.Expected_newline_after_directive, false);
+        
+        let scanNextToken = parseValidDirectiveEnd();
         scanner.setReportLineBreak(false);
         
         if (directive?.kind === SyntaxKind.IncludeDirective) {

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -315,6 +315,8 @@ exports[`Compiler compiler/ifelse.c Reports correct errors for compiler/ifelse.c
 
 exports[`Compiler compiler/include1.c Reports correct errors for compiler/include1.c: diags-compiler/include1.c 1`] = `""`;
 
+exports[`Compiler compiler/include2.c Reports correct errors for compiler/include2.c: diags-compiler/include2.c 1`] = `""`;
+
 exports[`Compiler compiler/indexAccess.c Reports correct errors for compiler/indexAccess.c: diags-compiler/indexAccess.c 1`] = `""`;
 
 exports[`Compiler compiler/indexAccess2.c Reports correct errors for compiler/indexAccess2.c: diags-compiler/indexAccess2.c 1`] = `""`;

--- a/server/src/tests/cases/compiler/include2.c
+++ b/server/src/tests/cases/compiler/include2.c
@@ -1,0 +1,8 @@
+// @files: includeFile.h
+
+test() {}
+
+// this include does not have a newline after it, which is legal
+// https://github.com/jlchmura/lpc-language-server/issues/184
+
+#include "includeFile.h"


### PR DESCRIPTION
- closes #184
- handle eof in parser after directive
- add unit test for 184
- changelog update