### PR TITLE
Scanner should allow whitespace in array/mapping literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LPC Language Services Changelog
 
+## 1.1.27
+
+-   Scanner should allow whitespace in array/mapping literal
+
 ## 1.1.26
 
 -   Package for deployment to NPM as [`@lpc-lang/core`](https://www.npmjs.com/package/@lpc-lang/core)

--- a/server/src/compiler/scanner.ts
+++ b/server/src/compiler/scanner.ts
@@ -2157,16 +2157,23 @@ export function createScanner(
                     // if (charCodeUnchecked(pos + 1) === CharacterCodes.colon && charCodeUnchecked(pos + 2) !== CharacterCodes.colon) {
                     //     return pos += 2, token = SyntaxKind.OpenParenColonToken;
                     // }
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.openBracket) {
-                        return pos += 2, token = SyntaxKind.OpenParenBracketToken;
-                    }     
-                    if (charCodeUnchecked(pos + 1) === CharacterCodes.openBrace) {
-                        return pos += 2, token = SyntaxKind.OpenParenBraceToken;
-                    }  
                     if (charCodeUnchecked(pos + 1) === CharacterCodes.asterisk) {
                         return pos += 2, token = SyntaxKind.OpenParenAsteriskToken;
                     }             
+                    
+                    // advance past paren, then skip whitespace                    
                     pos++;
+                    while (pos < end && isWhiteSpaceSingleLine(charCodeUnchecked(pos))) {
+                        pos++;
+                    }
+                    
+                    if (charCodeUnchecked(pos) === CharacterCodes.openBracket) {
+                        return pos += 1, token = SyntaxKind.OpenParenBracketToken;
+                    }     
+                    if (charCodeUnchecked(pos) === CharacterCodes.openBrace) {
+                        return pos += 1, token = SyntaxKind.OpenParenBraceToken;
+                    }  
+                                        
                     return token = SyntaxKind.OpenParenToken;
                 case CharacterCodes.closeParen:
                     pos++;

--- a/server/src/lpcserver/server.ts
+++ b/server/src/lpcserver/server.ts
@@ -15,7 +15,7 @@ import { getHeapStatistics } from "v8";
 // generate a unique 5 digit it
 // const randomId = Math.floor(Math.random() * 90000) + 10000;
 // const logFilename = `lpc-server-${randomId}.log`;
-const logger = new Logger("lpc-server.log", true, lpc.server.LogLevel.normal);
+const logger = new Logger(undefined, true, lpc.server.LogLevel.normal);
 // const origLog = console.log;
 // console.log = (...args) => { logger.info(args.length === 1 ? args[0] : args.join(", ")); origLog(...args); };
 // const origErr = console.error;

--- a/server/src/tests/cases/compiler/array5.c
+++ b/server/src/tests/cases/compiler/array5.c
@@ -1,0 +1,7 @@
+test() {
+
+    string *arr = ( { "a", "b" } );
+    
+}
+
+// allow whitespace in array initializer


### PR DESCRIPTION
Scanner should allow whitespace between open paren and brace/bracket for the start of literal arrays and mappings