### PR TITLE
Perf Improvement when editing included files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # LPC Language Services Changelog
 
+## 1.1.28
+
+-   Performance Improvement: Include files will now only trigger a re-parse of dependent files
+    if a) the dependent file is open in the editor or b) the number of dependent files is less than 25.
+
 ## 1.1.27
 
 -   Fix: Scanner should allow whitespace in array/mapping literal

--- a/lib/package.json
+++ b/lib/package.json
@@ -2,7 +2,7 @@
     "name": "@lpc-lang/core",
     "displayName": "LPC",
     "description": "LPC Language Compiler Library",
-    "version": "1.1.27",
+    "version": "1.1.28",
     "scripts": {      
     },
     "author": "jlchmura",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lpc",
     "displayName": "LPC",
-    "version": "1.1.27",
+    "version": "1.1.28",
     "galleryBanner": {
         "color": "#000000",
         "theme": "dark"

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -671,11 +671,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function initializeTypeChecker() {
         // Bind all source files and propagate errors
-        for (const file of host.getSourceFiles()) {            
-            if (file.isDefaultLib) {
-                const ii=0;
-            }
-            bindSourceFile(file, compilerOptions);            
+        for (const file of host.getSourceFiles()) {                        
+            bindSourceFile(file, compilerOptions);
         }
         
         // we'll use the globals concept to store driver efuns        
@@ -3299,6 +3296,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.EmptyStatement:            
             case SyntaxKind.JSDocClassTag:
             case SyntaxKind.JSDocSignature:
+            case SyntaxKind.UndefDirective:
                 return;
         }
 

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -699,22 +699,23 @@ export namespace LpcParser {
 
                 scanner.setReportLineBreak(false);
                 
-                // start the scan over
+                // start the scan over            
                 return nextTokenWithoutCheck();                
+            case SyntaxKind.Identifier:
+                if (allowMacroProcessing) {
+                    const tokenValue = scanner.getTokenValue();
+                    let macro: Macro;
+        
+                    // check macro params first - even if tokenValue matches a macro, we should not substitute if it is a macro param
+                    if (currentMacro && currentMacro.argsIn?.[tokenValue] && currentMacro.argsIn?.[tokenValue].disabled !== true) {
+                        return processMacroParamSubstitution(incomingToken, tokenValue, currentMacro);
+                    } else if ((macro = macroTable.get(tokenValue)) && macro.disabled !== true && macro.range) {                                
+                        return processMacroSubstitution(incomingToken, tokenValue, macro);
+                    } 
+                }
+                break;
         }
       
-        if (allowMacroProcessing && (incomingToken === SyntaxKind.Identifier)) {
-            const tokenValue = scanner.getTokenValue();
-            let macro = macroTable.get(tokenValue);
-
-            // check macro params first - even if tokenValue matches a macro, we should not substitute if it is a macro param
-            if (currentMacro && currentMacro.argsIn?.[tokenValue] && currentMacro.argsIn?.[tokenValue].disabled !== true) {
-                return processMacroParamSubstitution(incomingToken, tokenValue, currentMacro);
-            } else if (macro && macro.disabled !== true && macro.range) {                                
-                return processMacroSubstitution(incomingToken, tokenValue, macro);
-            } 
-        }
-        
         return currentToken = incomingToken;
     }
 

--- a/server/src/compiler/utilities.ts
+++ b/server/src/compiler/utilities.ts
@@ -2399,9 +2399,8 @@ export function canIncludeBindAndCheckDiagnostics(sourceFile: SourceFile, option
 
 // True if `name` is the name of a declaration node
 /** @internal */
-export function isDeclarationName(name: Node): boolean {
-    Debug.assertIsDefined(name.parent);
-    return !isSourceFile(name) && !isBindingPattern(name) && isDeclaration(name.parent) && name.parent.name === name;
+export function isDeclarationName(name: Node): boolean {    
+    return !isSourceFile(name) && !isBindingPattern(name) && name.parent && isDeclaration(name.parent) && name.parent.name === name;
 }
 
 /** @internal */

--- a/server/src/lpcserver/server.ts
+++ b/server/src/lpcserver/server.ts
@@ -112,6 +112,7 @@ export function start(connection: Connection, platform: string, args: string[]) 
     logger.info(`${logPrefix}Arguments: ${args.join(" ")}`);
     logger.info(`${logPrefix}Platform: ${platform} NodeVersion: ${process.version} CaseSensitive: ${lpc.sys.useCaseSensitiveFileNames}`);
     logger.info(`${logPrefix}ServerMode: ${serverMode}`)
+    logger.info(`${logPrefix}PID: ${process.pid}`);
     
     const locale = parseLocale();    
     logger.info(`${logPrefix}Locale: ${parseLocale()}`);    
@@ -172,7 +173,7 @@ export function start(connection: Connection, platform: string, args: string[]) 
         host.setTimeout = setTimeout;
         host.clearTimeout = clearTimeout;
         host.setImmediate = setImmediate;
-        host.clearImmediate = clearImmediate;            
+        host.clearImmediate = clearImmediate;       
         
         const session = new LspSession({
             host: lpc.sys as lpc.server.ServerHost,

--- a/server/src/server/types.ts
+++ b/server/src/server/types.ts
@@ -1,5 +1,6 @@
 import { DirectoryWatcherCallback, FileWatcher, FileWatcherCallback, ModuleImportResult, System, WatchOptions } from "./_namespaces/lpc";
 
+
 export interface ServerHost extends System {
     watchFile(path: string, callback: FileWatcherCallback, pollingInterval?: number, options?: WatchOptions): FileWatcher;
     watchDirectory(path: string, callback: DirectoryWatcherCallback, recursive?: boolean, options?: WatchOptions): FileWatcher;
@@ -12,7 +13,7 @@ export interface ServerHost extends System {
     trace?(s: string): void;
     require?(initialPath: string, moduleName: string): ModuleImportResult;
     /** @internal */
-    importPlugin?(root: string, moduleName: string): Promise<ModuleImportResult>;
+    importPlugin?(root: string, moduleName: string): Promise<ModuleImportResult>;    
 }
 
 export interface SymbolDisplayPart {

--- a/server/src/services/services.ts
+++ b/server/src/services/services.ts
@@ -2449,15 +2449,15 @@ class SyntaxTreeCache {
             })
         }; 
 
-        if (this.currentFileName !== fileName) {                       
+        // if (this.currentFileName !== fileName) {                       
             sourceFile = createLanguageServiceSourceFile(fileName, scriptSnapshot, options, version, /*setNodeParents*/ true, languageVariant, scriptKind);
-        }
-        else if (this.currentFileVersion !== version) {            
-            // This is the same file, just a newer version. Incrementally parse the file.
-            const editRange = scriptSnapshot.getChangeRange(this.currentFileScriptSnapshot!);
+        // }
+        // else if (this.currentFileVersion !== version) {            
+        //     // This is the same file, just a newer version. Incrementally parse the file.
+        //     const editRange = scriptSnapshot.getChangeRange(this.currentFileScriptSnapshot!);
                         
-            sourceFile = updateLanguageServiceSourceFile(this.currentSourceFile!, options.globalIncludes, options.configDefines, options.fileHandler, scriptSnapshot, version, editRange, languageVariant, false);
-        }
+        //     sourceFile = updateLanguageServiceSourceFile(this.currentSourceFile!, options.globalIncludes, options.configDefines, options.fileHandler, scriptSnapshot, version, editRange, languageVariant, false);
+        // }
 
         if (sourceFile) {
             // All done, ensure state is up to date


### PR DESCRIPTION
When editing a file that has been "imported" into other files via an `#include` directive, 
the server will not only invalidate dependent files (that is, those that include the file being edited) under two conditions:
1) if the dependent file is open in the editor
2) there are less than 25 files dependent on the include.

If those two conditions are not met, then the dependent files will be in a stale state until they are opened and an edit is made, which drastically improves performance - especially when editing a global include.