### PR TITLE
Allow newline whitespace in array/mapping literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LPC Language Services Changelog
 
+## 1.1.29
+
+-   Fix: [Mapping literal can have newline whitespace between `(` and `[` #202](https://github.com/jlchmura/lpc-language-server/issues/202)
+
 ## 1.1.28
 
 -   Lazy Parsing: The language server will now only parse files that are open in the editor or are directly dependent on an open file. This should reduce the memory footprint of the language server and improve performance. Note that running a language feature that analyzes multiple files (such as "Find All References") can still cause a large number of files to be parsed, so it is still recommended that projects be scoped as narrowly as possible using "include" and "exclude" config options.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lpc",
     "displayName": "LPC",
-    "version": "1.1.28",
+    "version": "1.1.29",
     "galleryBanner": {
         "color": "#000000",
         "theme": "dark"

--- a/server/src/compiler/scanner.ts
+++ b/server/src/compiler/scanner.ts
@@ -2163,7 +2163,7 @@ export function createScanner(
                     
                     // advance past paren, then skip whitespace                    
                     pos++;
-                    while (pos < end && isWhiteSpaceSingleLine(charCodeUnchecked(pos))) {
+                    while (pos < end && isWhiteSpaceLike(charCodeUnchecked(pos))) {
                         pos++;
                     }
                     

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -433,6 +433,8 @@ Found 2 errors in the same file, starting at: server/src/tests/cases/compiler/ma
 "
 `;
 
+exports[`Compiler compiler/mapping6.c Reports correct errors for compiler/mapping6.c: diags-compiler/mapping6.c 1`] = `""`;
+
 exports[`Compiler compiler/missingFunc.c Reports correct errors for compiler/missingFunc.c: diags-compiler/missingFunc.c 1`] = `
 "
 Found 1 error in server/src/tests/cases/compiler/missingFunc.c[90m:3[0m

--- a/server/src/tests/cases/compiler/mapping6.c
+++ b/server/src/tests/cases/compiler/mapping6.c
@@ -1,0 +1,9 @@
+private
+nosave mapping multiline_lit = (
+    ["metal":([128:"steel",
+                 64:"darksteel", 32:"silver", 16:"gold", 8:"platinum", 4:"titanium", 2:"adamantine", 1:"orichalcum", ]),
+        "wood":([128:"fir", 64:"pine", 32:"oak", 16:"cedar", 8:"larch", 4:"hemlock", 2:"ebony", 1:"bloodwood", ]), ]);
+
+// from LIMA: https://github.com/fluffos/lima/blob/dbcef2a9b2919474145e6a533fc434d67f6c7f5a/lib/daemons/crafting_d.c#L31
+
+// mapping literals can have whitespace (including newlines) between the ( and [ characters


### PR DESCRIPTION
- closes #202
- add unit test for #202
- changelog update
- bump version to 1.1.29