### PR TITLE
Fix parser incorrectly reporting circular include

### DIFF
--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -1955,11 +1955,11 @@ export namespace LpcParser {
             const includes = includeGraph.get(currentFile)!;
             includes.add(resolvedFilename);
         
-            // Check for circular includes
+            // Check for circular includes            
             if (hasCircularDependency(includeGraph, currentFile)) {
-                console.error(`Circular include detected: ${currentFile} -> ${resolvedFilename}`);
-                // report the error at the top-level include
-                parseErrorAtRange(currentTopLevelIncludeDirective ?? includeDirective, fileName, Diagnostics.Circular_include_detected_0_to_1, currentFile, resolvedFilename);
+                console.info(`Circular include ignored: ${currentFile} -> ${resolvedFilename}`);
+                // the drivers will ignore these, so we don't need to report an error
+                // parseErrorAtRange(currentTopLevelIncludeDirective ?? includeDirective, fileName, Diagnostics.Circular_include_detected_0_to_1, currentFile, resolvedFilename);
                 return false;
             }
             
@@ -1984,9 +1984,12 @@ export namespace LpcParser {
                 const revertStream = scanner.switchStream(
                     resolvedFilename, includeSourceText, 0, includeSourceText.length, false /* revertOnEOF */,
                     ()=>{
+                        includes.delete(resolvedFilename);
+
                         currentTopLevelIncludeDirective = saveTopDirective!;
                         currentIncludeDirective = saveDirective;
                         currentToken = scanner.getToken();
+
                         return false;
                     }
                 );            


### PR DESCRIPTION
- Pretty much any file in mg-mudlib would cause this. The parser was not removing include files from its dependency graph after they were parsed.
- A diagnostic is no longer reported for circular includes since the drivers will just ignore these.  A log entry is written to the language server log instead