### PR TITLE
declarations can have array with not element type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.31
 
 -   [Allow deprecated modifier #209](https://github.com/jlchmura/lpc-language-server/issues/209)
+-   [Function declaration can have an array indicator with no type #203](https://github.com/jlchmura/lpc-language-server/issues/203)
 
 ## 1.1.30
 

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -5191,9 +5191,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 links.resolvedType = node.kind === SyntaxKind.TupleType && node.elements.length === 0 ? target :
                     createDeferredTypeReference(target, node, /*mapper*/ undefined);
             }
-            else {                
-                const elementTypes = node.kind === SyntaxKind.ArrayType ? [getTypeFromTypeNode(node.elementType)] : map(node.elements, getTypeFromTypeNode);
-                links.resolvedType = createNormalizedTypeReference(target, elementTypes);
+            else if (node.kind === SyntaxKind.ArrayType) {
+                if (!node.elementType) {
+                    links.resolvedType = autoArrayType;
+                } else {
+                    links.resolvedType = createNormalizedTypeReference(target, [getTypeFromTypeNode(node.elementType)]);
+                }
+            } else {                                   
+                links.resolvedType = createNormalizedTypeReference(target, map(node.elements, getTypeFromTypeNode));
             }
         }
         return links.resolvedType;

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -1470,7 +1470,8 @@ export namespace LpcParser {
                 case SyntaxKind.MixedKeyword:
                 case SyntaxKind.VoidKeyword:                
                 case SyntaxKind.MappingKeyword:     
-                case SyntaxKind.LessThanToken: // start of array union type                                               
+                case SyntaxKind.LessThanToken: // start of array union type  
+                case SyntaxKind.AsteriskToken:                                             
                     return true;        
                     // const previousToken = token();
                     // nextToken();
@@ -1848,6 +1849,7 @@ export namespace LpcParser {
             case SyntaxKind.ObjectKeyword:            
             case SyntaxKind.Identifier:
             case SyntaxKind.LessThanToken: // start of union type                
+            case SyntaxKind.AsteriskToken: // See https://github.com/jlchmura/lpc-language-server/issues/203
                 if (isStartOfDeclaration()) {
                     return parseDeclaration();
                 }            

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -19,6 +19,15 @@ exports[`Compiler compiler/array4.c Reports correct errors for compiler/array4.c
 
 exports[`Compiler compiler/array5.c Reports correct errors for compiler/array5.c: diags-compiler/array5.c 1`] = `""`;
 
+exports[`Compiler compiler/array6.c Reports correct errors for compiler/array6.c: diags-compiler/array6.c 1`] = `""`;
+
+exports[`Compiler compiler/array7.c Reports correct errors for compiler/array7.c: diags-compiler/array7.c 1`] = `
+"
+Found 1 error in server/src/tests/cases/compiler/array7.c[90m:9[0m
+
+"
+`;
+
 exports[`Compiler compiler/assignment1.c Reports correct errors for compiler/assignment1.c: diags-compiler/assignment1.c 1`] = `""`;
 
 exports[`Compiler compiler/assignment2.c Reports correct errors for compiler/assignment2.c: diags-compiler/assignment2.c 1`] = `

--- a/server/src/tests/cases/compiler/array6.c
+++ b/server/src/tests/cases/compiler/array6.c
@@ -1,0 +1,8 @@
+* test() {
+
+    string *arr = ( { "a", "b" } );
+    return arr;
+    
+}
+
+// declaration can have an array indicator without a type

--- a/server/src/tests/cases/compiler/array7.c
+++ b/server/src/tests/cases/compiler/array7.c
@@ -1,0 +1,12 @@
+* test() {
+
+    string *arr = ( { "a", "b" } );
+    return arr;
+    
+}
+
+test2() {
+    int i = test(); // this should fail because because array cannot be assigned to int
+}
+
+// @errors: 1


### PR DESCRIPTION
- closes #203
- add unit tests
- adjust parser to allow * without type
- adjust type checker to return autoArray when no type node is provided