### PR TITLE
Allow modifiers in catch statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   [Allow deprecated modifier #209](https://github.com/jlchmura/lpc-language-server/issues/209)
 -   [Function declaration can have an array indicator with no type #203](https://github.com/jlchmura/lpc-language-server/issues/203)
+-   [Catch modifiers report parser error #207](https://github.com/jlchmura/lpc-language-server/issues/207)
 
 ## 1.1.30
 

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -5478,8 +5478,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     checkNoTypeArguments(node);
                     return !noImplicitAny ? anyType : undefined;
-                default:
-                    console.debug("todo - unhandled jsdoc type ref name " + node.typeName.text);
+                // default:
+                //     console.debug("todo - unhandled jsdoc type ref name " + node.typeName.text);
             }
         }
     }

--- a/server/src/compiler/factory/nodeFactory.ts
+++ b/server/src/compiler/factory/nodeFactory.ts
@@ -875,11 +875,13 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     }
 
     // @api
-    function createCatchStatement(expression: Expression | undefined, block: Block): CatchStatement {
+    function createCatchStatement(expression: Expression | undefined, block: Block, modifier?: Identifier, modifierExpression?: Expression): CatchStatement {
         const node = createBaseNode<CatchStatement>(SyntaxKind.CatchStatement);
         node.expression = expression;
         node.block = block;
-        
+        node.modifier = modifier;
+        node.modifierExpression = modifierExpression;
+                
         node.transformFlags |= propagateChildFlags(node.expression) |
             propagateChildFlags(node.block);
 

--- a/server/src/compiler/types.ts
+++ b/server/src/compiler/types.ts
@@ -1603,7 +1603,7 @@ export interface NodeFactory {
     createWhileStatement(statement: Statement, expression: Expression): WhileStatement;
     createParameterDeclaration(modifiers: readonly Modifier[] | undefined, dotDotDotToken: DotDotDotToken | undefined, name: string | BindingName, ampToken?: AmpersandToken | RefToken, type?: TypeNode, initializer?: Expression): ParameterDeclaration;
     /** @internal */ createMissingDeclaration(): MissingDeclaration;
-    createCatchStatement(expression: Expression | undefined, block: Block): CatchStatement;
+    createCatchStatement(expression: Expression | undefined, block: Block, modifier?: Identifier, modifierExpression?: Expression): CatchStatement;
 
     // Expressions
     createExpressionWithTypeArguments(expression: Expression, typeArguments: readonly TypeNode[] | undefined): ExpressionWithTypeArguments;
@@ -3615,6 +3615,8 @@ export interface CatchStatement extends Statement, LocalsContainer {
     readonly parent: Block;
     readonly expression?: Expression;
     readonly block: Block;
+    readonly modifier?: Identifier;
+    readonly modifierExpression?: Expression;
 }
 
 export interface CatchExpression extends PrimaryExpression {

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -126,6 +126,8 @@ Found 1 error in server/src/tests/cases/compiler/catchBlock3.c[90m:4[0m
 "
 `;
 
+exports[`Compiler compiler/catchBlock4.c Reports correct errors for compiler/catchBlock4.c: diags-compiler/catchBlock4.c 1`] = `""`;
+
 exports[`Compiler compiler/catchExpr1.c Reports correct errors for compiler/catchExpr1.c: diags-compiler/catchExpr1.c 1`] = `""`;
 
 exports[`Compiler compiler/class1.c Reports correct errors for compiler/class1.c: diags-compiler/class1.c 1`] = `""`;

--- a/server/src/tests/cases/compiler/catchBlock4.c
+++ b/server/src/tests/cases/compiler/catchBlock4.c
@@ -1,0 +1,9 @@
+test() {
+    object o = clone_object("object.c");
+    catch(o->query_number(); publish);
+}
+
+// catch statements can have modifiers in LD
+
+// @files: object.c
+// @driver: ldmud


### PR DESCRIPTION
- closes #207 
- add unit test
- add mofier to catch statement parsing and AST node