### PR TITLE
Allow `&` in an LD foreach expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   [Allow deprecated modifier #209](https://github.com/jlchmura/lpc-language-server/issues/209)
 -   [Function declaration can have an array indicator with no type #203](https://github.com/jlchmura/lpc-language-server/issues/203)
 -   [Catch modifiers report parser error #207](https://github.com/jlchmura/lpc-language-server/issues/207)
+-   Allow `&` in an LD foreach expression
 
 ## 1.1.30
 

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -2225,13 +2225,10 @@ export namespace LpcParser {
         parseExpected(SyntaxKind.OpenParenToken);
         
         let initializer!: VariableDeclarationList | Expression;
-        if (
-            isTypeName()// && lookAhead(nextTokenIsIdentifierOrKeyword)
-        ) {
+        if (isTypeName() /*&& lookAhead(nextTokenIsIdentifierOrKeyword)*/) {
             // const type = parseType();
             initializer = parseVariableDeclarationList(/*inForStatementInitializer*/ true, undefined, ParsingContext.ForEachInitializers);
-        }
-        else {
+        } else {
             initializer = disallowInAnd(parseExpression);
         }
 
@@ -2241,8 +2238,8 @@ export namespace LpcParser {
             isColon=true;
             parseExpected(SyntaxKind.ColonToken);
         }
-
-        const expression = parseMaybeRangeExpression(SyntaxKind.CloseParenToken);
+        
+        const expression = isLDMud && isRefElement() ? parseByRefElement() : parseMaybeRangeExpression(SyntaxKind.CloseParenToken);
         parseExpected(SyntaxKind.CloseParenToken);
         const body = parseStatement();
 
@@ -3554,6 +3551,20 @@ export namespace LpcParser {
             || token() === SyntaxKind.LessThanToken // union type
             || isTypeName()
             || isLiteralPropertyName();
+    }
+
+    function isLDMud(): boolean {
+        return languageVariant === LanguageVariant.LDMud;
+    }
+
+    function isRefElement(): boolean {
+        switch (token()) {
+            case SyntaxKind.AmpersandToken:
+            case SyntaxKind.RefKeyword:
+                return true;
+            default:
+                return false;
+        }
     }
 
     function isTypeName(): boolean {

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -310,6 +310,8 @@ exports[`Compiler compiler/forEach10.c Reports correct errors for compiler/forEa
 
 exports[`Compiler compiler/forEachRef.c Reports correct errors for compiler/forEachRef.c: diags-compiler/forEachRef.c 1`] = `""`;
 
+exports[`Compiler compiler/forEachRef2.c Reports correct errors for compiler/forEachRef2.c: diags-compiler/forEachRef2.c 1`] = `""`;
+
 exports[`Compiler compiler/funcDecl1.c Reports correct errors for compiler/funcDecl1.c: diags-compiler/funcDecl1.c 1`] = `""`;
 
 exports[`Compiler compiler/funcDecl2.c Reports correct errors for compiler/funcDecl2.c: diags-compiler/funcDecl2.c 1`] = `""`;

--- a/server/src/tests/cases/compiler/forEachRef2.c
+++ b/server/src/tests/cases/compiler/forEachRef2.c
@@ -1,0 +1,13 @@
+
+test() {
+    int *arr = ({1, 2, 3});
+    foreach(int x in &arr) {
+        x++;        
+    }
+}
+
+/*
+ * LD allows a ref in the foreach loop target
+ */
+
+// @driver: ldmud


### PR DESCRIPTION
- adjust foreach parser
- add unit test