### PR TITLE
`buffer` and `in` are not reserved words in LD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   [Function macro with array arg parsed incorrectly. #220](https://github.com/jlchmura/lpc-language-server/issues/220)
 -   Fix crash on signature help when typing a macro function without args.
 -   Fix possible max call stack crash with large or open-ended code ranges that are disabled.
+-   Fix: `buffer` and `in` are not reserved words in LD.
 
 ## 1.1.31
 

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -1470,8 +1470,7 @@ export namespace LpcParser {
                 case SyntaxKind.NoShadowKeyword:
                 case SyntaxKind.BytesKeyword:                
                 case SyntaxKind.LwObjectKeyword:
-                // case SyntaxKind.ClosureKeyword:                
-                case SyntaxKind.BufferKeyword:
+                // case SyntaxKind.ClosureKeyword:                                
                 case SyntaxKind.IntKeyword:
                 case SyntaxKind.FloatKeyword:
                 case SyntaxKind.StringKeyword:
@@ -1492,12 +1491,16 @@ export namespace LpcParser {
                     // //     // report Line_break_not_permitted_here if needed.
                     // //     return true;
                     // // }
-                    // continue;        
+                    // continue;                        
                 case SyntaxKind.ObjectKeyword:
                     return lookAhead(()=>nextToken() !== SyntaxKind.ColonColonToken);        
                 case SyntaxKind.StatusKeyword:
                 case SyntaxKind.SymbolKeyword:
+                    // LD only
                     return languageVariant === LanguageVariant.LDMud;
+                case SyntaxKind.BufferKeyword:
+                    // Fluff only
+                    return languageVariant === LanguageVariant.FluffOS;
                 case SyntaxKind.Identifier:
                     // probably a function without modifier or type
                     // but that can only happen if we're parsing in the source context
@@ -3161,8 +3164,7 @@ export namespace LpcParser {
             case SyntaxKind.StatusKeyword:
             case SyntaxKind.LwObjectKeyword:
             case SyntaxKind.ClosureKeyword:
-            case SyntaxKind.SymbolKeyword:
-            case SyntaxKind.BufferKeyword:
+            case SyntaxKind.SymbolKeyword:            
             case SyntaxKind.IntKeyword:
             case SyntaxKind.FloatKeyword:
             case SyntaxKind.MixedKeyword:
@@ -3203,6 +3205,9 @@ export namespace LpcParser {
                     return true;
                 }
                 // fall through
+            case SyntaxKind.BufferKeyword:
+                // fluff-only keywords                
+                return languageVariant === LanguageVariant.FluffOS;
             default:
                 return isIdentifier();
         }
@@ -3220,8 +3225,7 @@ export namespace LpcParser {
             case SyntaxKind.StringKeyword:
             case SyntaxKind.BytesKeyword:            
             case SyntaxKind.LwObjectKeyword:
-            case SyntaxKind.ClosureKeyword:            
-            case SyntaxKind.BufferKeyword:            
+            case SyntaxKind.ClosureKeyword:                        
             case SyntaxKind.IntKeyword:
             case SyntaxKind.FloatKeyword:
             case SyntaxKind.FunctionKeyword:
@@ -3234,6 +3238,9 @@ export namespace LpcParser {
             case SyntaxKind.SymbolKeyword:  
                 // status is only available in LD           
                 return languageVariant === LanguageVariant.LDMud ? parseKeywordAndNoDot() : undefined;
+            case SyntaxKind.BufferKeyword:            
+                // buffer is only available in FluffOS
+                return languageVariant === LanguageVariant.FluffOS ? parseKeywordAndNoDot() : undefined;
             case SyntaxKind.ObjectKeyword:
                 // LD has "named" objects.  
                 const pos = getPositionState();              
@@ -3579,8 +3586,7 @@ export namespace LpcParser {
         switch (token()) {
             case SyntaxKind.BytesKeyword:            
             case SyntaxKind.LwObjectKeyword:
-            case SyntaxKind.ClosureKeyword:            
-            case SyntaxKind.BufferKeyword:
+            case SyntaxKind.ClosureKeyword:                        
             case SyntaxKind.TrueKeyword:
             case SyntaxKind.FalseKeyword:
             case SyntaxKind.IntKeyword:
@@ -3603,6 +3609,8 @@ export namespace LpcParser {
             case SyntaxKind.StatusKeyword:
             case SyntaxKind.SymbolKeyword:
                 return languageVariant === LanguageVariant.LDMud;
+            case SyntaxKind.BufferKeyword:
+                return languageVariant === LanguageVariant.FluffOS;
             case SyntaxKind.NullKeyword:
                 return languageVersion === ScriptTarget.JSON;
         }        

--- a/server/src/compiler/types.ts
+++ b/server/src/compiler/types.ts
@@ -765,13 +765,11 @@ export const enum SyntaxKind {
     StructKeyword,
     CatchKeyword,    
     MixedKeyword,
-    UnknownKeyword,    
-    InKeyword,
+    UnknownKeyword,        
     MappingKeyword,
     VoidKeyword,
     BreakKeyword,
-    BytesKeyword,
-    BufferKeyword,    
+    BytesKeyword,    
     DoKeyword,
     ElseKeyword,
     ForKeyword,
@@ -810,9 +808,11 @@ export const enum SyntaxKind {
     SymbolKeyword,      // not reserved in fluffos
     ObjectKeyword,      // can occur in a super expr i.e.  object::fn()
     RefKeyword,         // fluff only
+    BufferKeyword,      // fluff only
     IsKeyword,          // use for type predicates only
     FunctionsKeyword,   // inherit modifier
     VirtualKeyword,     // inherit modifier
+    InKeyword,          // not a reserved word in LD (maybe fluff?)
     NewKeyword,         // LastKeyword and LastToken - everything after this will be processed by the binder
 
     // Parse Tree Nodes

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -98,6 +98,8 @@ Found 1 error in server/src/tests/cases/compiler/badSwitch.c[90m:7[0m
 
 exports[`Compiler compiler/buffer1.c Reports correct errors for compiler/buffer1.c: diags-compiler/buffer1.c 1`] = `""`;
 
+exports[`Compiler compiler/buffer2.c Reports correct errors for compiler/buffer2.c: diags-compiler/buffer2.c 1`] = `""`;
+
 exports[`Compiler compiler/bytes1.c Reports correct errors for compiler/bytes1.c: diags-compiler/bytes1.c 1`] = `""`;
 
 exports[`Compiler compiler/callOther1.c Reports correct errors for compiler/callOther1.c: diags-compiler/callOther1.c 1`] = `""`;
@@ -346,6 +348,8 @@ exports[`Compiler compiler/if2.c Reports correct errors for compiler/if2.c: diag
 exports[`Compiler compiler/if3.c Reports correct errors for compiler/if3.c: diags-compiler/if3.c 1`] = `""`;
 
 exports[`Compiler compiler/ifelse.c Reports correct errors for compiler/ifelse.c: diags-compiler/ifelse.c 1`] = `""`;
+
+exports[`Compiler compiler/in1.c Reports correct errors for compiler/in1.c: diags-compiler/in1.c 1`] = `""`;
 
 exports[`Compiler compiler/include1.c Reports correct errors for compiler/include1.c: diags-compiler/include1.c 1`] = `""`;
 

--- a/server/src/tests/cases/compiler/buffer2.c
+++ b/server/src/tests/cases/compiler/buffer2.c
@@ -1,0 +1,10 @@
+
+string buffer = "abc";
+
+string test(string buffer) {
+    return buffer;
+}
+
+// buffer is not a reserved word in LD
+
+// @driver: ldmud

--- a/server/src/tests/cases/compiler/in1.c
+++ b/server/src/tests/cases/compiler/in1.c
@@ -1,0 +1,11 @@
+string test() {
+    string in;
+    in = "abc";
+    return in;
+}
+
+/*
+ * `in` is not a reserved word in LD
+ */
+
+// @driver: ldmud


### PR DESCRIPTION
- add unit tests