### PR TITLE
Signature Help, Completion, and Hover formatting fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # LPC Language Services Changelog
 
+## 1.1.33
+
+-   Add `never` type to type checker node builder.
+
 ## 1.1.32
 
 -   [Function macro with array arg parsed incorrectly. #220](https://github.com/jlchmura/lpc-language-server/issues/220)
 -   [Inline closure should allow statements #206](https://github.com/jlchmura/lpc-language-server/issues/206)
 -   [Class is not a reserved word in LD #224](https://github.com/jlchmura/lpc-language-server/issues/224)
 -   [tooltip for typed object reference from a macro not showing completely or fully, when using LD's syntax #227](https://github.com/jlchmura/lpc-language-server/issues/227)
--   [@type not expanding macros in tooltip #228](https://github.com/jlchmura/lpc-language-server/issues/228)
+-   [`@type` not expanding macros in tooltip #228](https://github.com/jlchmura/lpc-language-server/issues/228)
 -   Fix crash on signature help when typing a macro function without args.
 -   Fix possible max call stack crash with large or open-ended code ranges that are disabled.
 -   Fix: `buffer` and `in` are not reserved words in LD.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   [LPCDoc param names garbled when forward define is in another file #233](https://github.com/jlchmura/lpc-language-server/issues/233)
 -   [Feat: get it to stop counting forward declaration as an overload #229](https://github.com/jlchmura/lpc-language-server/issues/229)
+-   Fix: Display `mapping` keyword instead of global mapping symbol name.
 -   Add `never` type to type checker node builder.
 
 ## 1.1.32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   [LPCDoc param names garbled when forward define is in another file #233](https://github.com/jlchmura/lpc-language-server/issues/233)
 -   [Feat: get it to stop counting forward declaration as an overload #229](https://github.com/jlchmura/lpc-language-server/issues/229)
 -   Fix: Display `mapping` keyword instead of global mapping symbol name.
+-   Fix: Function return type was not displayed in completions detail.
 -   Add `never` type to type checker node builder.
 
 ## 1.1.32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.33
 
 -   [LPCDoc param names garbled when forward define is in another file #233](https://github.com/jlchmura/lpc-language-server/issues/233)
+-   [Feat: get it to stop counting forward declaration as an overload #229](https://github.com/jlchmura/lpc-language-server/issues/229)
 -   Add `never` type to type checker node builder.
 
 ## 1.1.32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.33
 
+-   [LPCDoc param names garbled when forward define is in another file #233](https://github.com/jlchmura/lpc-language-server/issues/233)
 -   Add `never` type to type checker node builder.
 
 ## 1.1.32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -   [Feat: get it to stop counting forward declaration as an overload #229](https://github.com/jlchmura/lpc-language-server/issues/229)
 -   Fix: Display `mapping` keyword instead of global mapping symbol name.
 -   Fix: Function return type was not displayed in completions detail.
+-   Fix: Signature help return type should be LPC-style, not TypeScript.
 -   Add `never` type to type checker node builder.
 
 ## 1.1.32

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -19739,10 +19739,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             //     context.approximateLength += 4;
             //     return factory.createLiteralTypeNode(factory.createNull());
             // }
-            // if (type.flags & TypeFlags.Never) {
-            //     context.approximateLength += 5;
-            //     return factory.createKeywordTypeNode(SyntaxKind.NeverKeyword);
-            // }
+            if (type.flags & TypeFlags.Never) {
+                context.approximateLength += 5;
+                return factory.createKeywordTypeNode(SyntaxKind.NeverKeyword);
+            }
             // if (type.flags & TypeFlags.ESSymbol) {
             //     context.approximateLength += 6;
             //     return factory.createKeywordTypeNode(SyntaxKind.SymbolKeyword);

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -20267,7 +20267,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             function typeReferenceToTypeNode(type: TypeReference) {
                 let typeArguments: readonly Type[] = getTypeArguments(type);
-                if (type.target === globalArrayType || type.target === globalReadonlyArrayType) {
+                
+                if (type.target === globalMappingType) {
+                    return factory.createTypeReferenceNode("mapping");
+                }                
+                else if (type.target === globalArrayType || type.target === globalReadonlyArrayType) {
                     if (context.flags & NodeBuilderFlags.WriteArrayAsGenericType) {
                         const typeArgumentNode = typeToTypeNodeHelper(typeArguments[0], context);
                         return factory.createTypeReferenceNode(type.target === globalArrayType ? "Array" : "ReadonlyArray", [typeArgumentNode]);

--- a/server/src/compiler/types.ts
+++ b/server/src/compiler/types.ts
@@ -805,6 +805,7 @@ export const enum SyntaxKind {
     FalseKeyword,       // JSON-only
     TrueKeyword,        // JSON-only
     NullKeyword,        // JSON-only    
+    NeverKeyword,       // typenode only
     FunctionKeyword,    // can be used as a param name
     SymbolKeyword,      // not reserved in fluffos
     ObjectKeyword,      // can occur in a super expr i.e.  object::fn()
@@ -1401,6 +1402,7 @@ export type KeywordTypeSyntaxKind =
     // | SyntaxKind.SymbolKeyword
     | SyntaxKind.UndefinedKeyword
     | SyntaxKind.UnknownKeyword
+    | SyntaxKind.NeverKeyword
     | SyntaxKind.VoidKeyword;    
 
 export type TokenSyntaxKind =
@@ -2388,6 +2390,7 @@ export type KeywordSyntaxKind =
     | SyntaxKind.InheritKeyword
     | SyntaxKind.NewKeyword
     | SyntaxKind.NullKeyword
+    | SyntaxKind.NeverKeyword
     | SyntaxKind.ReturnKeyword
     | SyntaxKind.SwitchKeyword
     | SyntaxKind.WhileKeyword

--- a/server/src/compiler/utilities.ts
+++ b/server/src/compiler/utilities.ts
@@ -2639,7 +2639,7 @@ export function getTokenPosOfNode(node: Node, sourceFile?: SourceFileLike, inclu
 
     if (isJSDocNode(node)) {
         // JsxText cannot actually contain comments, even though the scanner will think it sees comments
-        return skipTrivia((sourceFile ?? getSourceFileOfNode(node)).text, node.pos, /*stopAfterLineBreak*/ false, /*stopAtComments*/ true);
+        return skipTrivia((sourceFile ?? getSourceFileOrIncludeOfNode(node)).text, node.pos, /*stopAfterLineBreak*/ false, /*stopAtComments*/ true);
     }
     
     if (includeJsDoc && hasJSDocNodes(node)) {
@@ -2651,14 +2651,14 @@ export function getTokenPosOfNode(node: Node, sourceFile?: SourceFileLike, inclu
     // trivia for the list, we may have skipped the JSDocComment as well. So we should process its
     // first child to determine the actual position of its first token.
     if (node.kind === SyntaxKind.SyntaxList) {
-        sourceFile ??= getSourceFileOfNode(node);
+        sourceFile ??= getSourceFileOrIncludeOfNode(node);
         const first = firstOrUndefined(getNodeChildren(node, sourceFile));
         if (first) {
             return getTokenPosOfNode(first, sourceFile, includeJsDoc);
         }
     }
 
-    const text = (sourceFile ?? getSourceFileOfNode(node))?.text;
+    const text = (sourceFile ?? getSourceFileOrIncludeOfNode(node))?.text;
     return text ? skipTrivia(
         text,
         node.pos,

--- a/server/src/server/session.ts
+++ b/server/src/server/session.ts
@@ -1105,7 +1105,7 @@ export class Session<TMessage = string> implements EventSender {
         const scriptInfo = this.projectService.getScriptInfoForNormalizedPath(file)!;
         const position = this.getPosition(args, scriptInfo);
         const formattingOptions = project.projectService.getFormatCodeOptions(file);
-        const useDisplayParts = !!this.getPreferences(file).displayPartsForJSDoc;
+        const useDisplayParts = true;// !!this.getPreferences(file).displayPartsForJSDoc;
 
         const result = mapDefined(args.entryNames, entryName => {
             const { name, source, data } = typeof entryName === "string" ? { name: entryName, source: undefined, data: undefined } : entryName;

--- a/server/src/server/session.ts
+++ b/server/src/server/session.ts
@@ -659,7 +659,7 @@ export class Session<TMessage = string> implements EventSender {
         const scriptInfo = this.projectService.getScriptInfoForNormalizedPath(file)!;
         const position = this.getPosition(args, scriptInfo);
         const helpItems = project.getLanguageService().getSignatureHelpItems(file, position, args);
-        const useDisplayParts = !!this.getPreferences(file).displayPartsForJSDoc;
+        const useDisplayParts = true;//!!this.getPreferences(file).displayPartsForJSDoc;
         if (helpItems && simplifiedResult) {
             const span = helpItems.applicableSpan;
             return {

--- a/server/src/services/services.ts
+++ b/server/src/services/services.ts
@@ -204,6 +204,8 @@ import {
     CheckLpcDirective,
     bindSourceFile,
     tryGetTextOfPropertyName,
+    getSourceFileOrIncludeOfNode,
+    SourceFileBase,
 } from "./_namespaces/lpc.js";
 import * as classifier2020 from "./classifier2020.js";
 import { computeSuggestionDiagnostics } from "./suggestionDiagnostics.js";
@@ -256,6 +258,10 @@ class TokenOrIdentifierObject<TKind extends SyntaxKind> implements Node {
         return getSourceFileOfNode(this);
     }
 
+    public getSourceFileOrInclude(): SourceFileBase {
+        return getSourceFileOrIncludeOfNode(this);
+    }
+
     public getStart(
         sourceFile?: SourceFileLike,
         includeJsDocComment?: boolean
@@ -271,7 +277,7 @@ class TokenOrIdentifierObject<TKind extends SyntaxKind> implements Node {
         return this.end;
     }
 
-    public getWidth(sourceFile?: SourceFile): number {        
+    public getWidth(sourceFile?: SourceFileBase): number {        
         return this.getEnd() - this.getStart(sourceFile);        
     }
 
@@ -279,20 +285,20 @@ class TokenOrIdentifierObject<TKind extends SyntaxKind> implements Node {
         return this.end - this.pos;
     }
 
-    public getLeadingTriviaWidth(sourceFile?: SourceFile): number {
+    public getLeadingTriviaWidth(sourceFile?: SourceFileBase): number {
         return this.getStart(sourceFile) - this.pos;
     }
 
-    public getFullText(sourceFile?: SourceFile): string {
-        return (sourceFile || this.getSourceFile()).text.substring(
+    public getFullText(sourceFile?: SourceFileBase): string {
+        return (sourceFile || this.getSourceFileOrInclude()).text.substring(
             this.pos,
             this.end
         );
     }
 
-    public getText(sourceFile?: SourceFile): string {
+    public getText(sourceFile?: SourceFileBase): string {
         if (!sourceFile) {
-            sourceFile = this.getSourceFile();
+            sourceFile = this.getSourceFileOrInclude();
             Debug.assertIsDefined(sourceFile);
         }
         return sourceFile.text.substring(
@@ -408,6 +414,10 @@ class NodeObject<TKind extends SyntaxKind> implements Node {
         return getSourceFileOfNode(this);
     }
 
+    public getSourceFileOrInclude(): SourceFileBase {
+        return getSourceFileOrIncludeOfNode(this);
+    }
+
     public getStart(
         sourceFile?: SourceFileLike,
         includeJsDocComment?: boolean
@@ -436,23 +446,23 @@ class NodeObject<TKind extends SyntaxKind> implements Node {
         return this.end - this.pos;
     }
 
-    public getLeadingTriviaWidth(sourceFile?: SourceFile): number {
+    public getLeadingTriviaWidth(sourceFile?: SourceFileBase): number {
         this.assertHasRealPosition();
         return this.getStart(sourceFile) - this.pos;
     }
 
-    public getFullText(sourceFile?: SourceFile): string {
+    public getFullText(sourceFile?: SourceFileBase): string {
         this.assertHasRealPosition();
-        return (sourceFile || this.getSourceFile()).text.substring(
+        return (sourceFile || this.getSourceFileOrInclude()).text.substring(
             this.pos,
             this.end
         );
     }
 
-    public getText(sourceFile?: SourceFile): string {
+    public getText(sourceFile?: SourceFileBase): string {
         this.assertHasRealPosition();
         if (!sourceFile) {
-            sourceFile = this.getSourceFile();
+            sourceFile = this.getSourceFileOrInclude();
         }
         return sourceFile.text.substring(
             this.getStart(sourceFile),

--- a/server/src/services/signatureHelp.ts
+++ b/server/src/services/signatureHelp.ts
@@ -600,8 +600,8 @@ const separatorDisplayParts: SymbolDisplayPart[] = [punctuationPart(SyntaxKind.C
 function getSignatureHelpItem(candidateSignature: Signature, callTargetDisplayParts: readonly SymbolDisplayPart[], isTypeParameterList: boolean, checker: TypeChecker, enclosingDeclaration: Node, sourceFile: SourceFile): SignatureHelpItem[] {
     const infos = (isTypeParameterList ? itemInfoForTypeParameters : itemInfoForParameters)(candidateSignature, checker, enclosingDeclaration, sourceFile);
     return map(infos, ({ isVariadic, parameters, prefix, suffix }) => {
-        const prefixDisplayParts = [...callTargetDisplayParts, ...prefix];
-        const suffixDisplayParts = [...suffix, ...returnTypeToDisplayParts(candidateSignature, enclosingDeclaration, checker)];
+        const prefixDisplayParts = [...returnTypeToDisplayParts(candidateSignature, enclosingDeclaration, checker), ...callTargetDisplayParts, ...prefix];
+        const suffixDisplayParts = [...suffix];
         const documentation = candidateSignature.getDocumentationComment(checker);
         const tags = candidateSignature.getJsDocTags();
         return { isVariadic, prefixDisplayParts, suffixDisplayParts, separatorDisplayParts, parameters, documentation, tags };
@@ -640,14 +640,15 @@ function createSignatureHelpParameterForParameter(parameter: Symbol, checker: Ty
 
 function returnTypeToDisplayParts(candidateSignature: Signature, enclosingDeclaration: Node, checker: TypeChecker): readonly SymbolDisplayPart[] {
     return mapToDisplayParts(writer => {
-        writer.writePunctuation(":");
-        writer.writeSpace(" ");
+        // writer.writePunctuation(":");
+        // writer.writeSpace(" ");
         const predicate = checker.getTypePredicateOfSignature(candidateSignature);
         if (predicate) {
             checker.writeTypePredicate(predicate, enclosingDeclaration, /*flags*/ undefined, writer);
         }
         else {
             checker.writeType(checker.getReturnTypeOfSignature(candidateSignature), enclosingDeclaration, /*flags*/ undefined, writer);
+            writer.writeSpace(" ");
         }
     });
 }

--- a/server/src/services/symbolDisplay.ts
+++ b/server/src/services/symbolDisplay.ts
@@ -1380,7 +1380,8 @@ function getSymbolDisplayPartsDocumentationAndSymbolKindWorker(typeChecker: Type
     }
 
     function addSignatureDisplayPartsHelper(signature: Signature, allSignatures: readonly Signature[], flags = TypeFormatFlags.None) {
-        if (allSignatures.length > 1) {
+        // only display overload indicator for efuns        
+        if (allSignatures.length > 1 && signature.declaration && getSourceFileOfNode(signature.declaration)?.isDefaultLib) {
             displayParts.push(spacePart());
             displayParts.push(punctuationPart(SyntaxKind.OpenParenToken));
             displayParts.push(operatorPart(SyntaxKind.PlusToken));

--- a/server/src/services/symbolDisplay.ts
+++ b/server/src/services/symbolDisplay.ts
@@ -11,6 +11,7 @@ import {
     displayPart,    
     find,
     first,    
+    firstOrUndefined,    
     forEach,
     getCombinedLocalAndExportSymbolFlags,
     getDeclarationOfKind,
@@ -1177,7 +1178,7 @@ function getSymbolDisplayPartsDocumentationAndSymbolKindWorker(typeChecker: Type
                     symbolKind === ScriptElementKind.localVariableElement ||
                     symbolKind === ScriptElementKind.indexSignatureElement ||
                     symbolKind === ScriptElementKind.variableUsingElement ||
-                    symbolKind === ScriptElementKind.variableAwaitUsingElement ||
+                    symbolKind === ScriptElementKind.variableAwaitUsingElement ||                    
                     isThisExpression
                 ) {
                     // displayParts.push(punctuationPart(SyntaxKind.ColonToken));                    
@@ -1194,6 +1195,15 @@ function getSymbolDisplayPartsDocumentationAndSymbolKindWorker(typeChecker: Type
                     addRange(displayParts, typeToDisplayParts(typeChecker, type, enclosingDeclaration));
                     displayParts.push(spacePart());
                     // }                    
+                }
+                else if (symbolKind === ScriptElementKind.functionElement) {
+                    // add the return type for a function
+                    const callSig = firstOrUndefined(type.getCallSignatures());
+                    const callSignReturnType = callSig?.getReturnType();
+                    if (callSignReturnType) {
+                        addRange(displayParts, typeToDisplayParts(typeChecker, callSignReturnType));
+                        displayParts.push(spacePart());
+                    }
                 }
 
                 addFullSymbolName(symbol);

--- a/server/src/services/types.ts
+++ b/server/src/services/types.ts
@@ -70,6 +70,7 @@ declare module "../compiler/types.js" {
     // Module transform: converted from interface augmentation
     export interface Node {
         getSourceFile(): SourceFile;
+        getSourceFileOrInclude(): SourceFileBase;
         getChildCount(sourceFile?: SourceFile): number;
         getChildAt(index: number, sourceFile?: SourceFile): Node;
         getChildren(sourceFile?: SourceFile): readonly Node[];


### PR DESCRIPTION
-   [Feat: get it to stop counting forward declaration as an overload #229](https://github.com/jlchmura/lpc-language-server/issues/229)
-   Fix: Display `mapping` keyword instead of global mapping symbol name.
-   Fix: Function return type was not displayed in completions detail.
-   Fix: Signature help return type should be LPC-style, not TypeScript.