### PR TITLE
remove deprecated enabled_commands(void)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.36
 
 -   [macros named null are not resolving correctly #245](https://github.com/jlchmura/lpc-language-server/issues/245)
+-   [deprecation for enable_commands(void) may not be correct #244](https://github.com/jlchmura/lpc-language-server/issues/244)
 
 ## 1.1.35
 

--- a/efuns/fluffos/interactive.h
+++ b/efuns/fluffos/interactive.h
@@ -634,27 +634,6 @@ int exec( object to, object from );
  * When setup_actions > 0, Driver will re-setup all the actions by calling
  * init()  on  its  environment,  sibling  and inventory objects. (in that
  * order).
- * @deprecated
- */
-void enable_commands(  );
-
-/**
- * enable_commands() - allow object to use 'player' commands
- *
- * enable_commands() marks this_object() as a living object, and allows it
- * to use commands added with add_action()  (by  using  command()).   When
- * enable_commands()  is called, the driver also looks for the local func‐
- * tion catch_tell(), and if found, it will call it every time  a  message
- * (via say() for example) is given to the object.
- * 
- * Since  FluffOS  3.0-alpha7: This function now accept int, default to 0.
- * which has same meaning of old form.  which merely re-enables  commands,
- * but  don't  setup actions. (it should have been cleared when previously
- * called disable_commands())
- * 
- * When setup_actions > 0, Driver will re-setup all the actions by calling
- * init()  on  its  environment,  sibling  and inventory objects. (in that
- * order).
  * @param {int} setup_actions - if non-zero, re-setup actions by calling init() on its environment, sibling and inventory objects. Defaults to 0
  * @since 3.0-alpha7.1* 
  */

--- a/efuns/fluffos/zh-cn/interactive.zh-cn.h
+++ b/efuns/fluffos/zh-cn/interactive.zh-cn.h
@@ -519,23 +519,6 @@ object find_player( string str );
  */
 int exec( object to, object from );
 
-/**
- * enable_commands() - 允许对象使用“玩家”命令
- *
- * enable_commands() 将 this_object() 标记为一个活对象，并允许它
- * 使用 add_action() 添加的命令（通过使用 command()）。当
- * enable_commands() 被调用时，驱动程序还会寻找本地功能
- * catch_tell()，如果找到了，每次向该对象发送消息（通过 say() 例如）时都会调用它。
- * 
- * 自 FluffOS 3.0-alpha7 起：此函数现在接受 int，默认为 0。
- * 这与旧形式的含义相同，仅仅是重新启用命令，但并没有
- * 设置动作。（它应该在之前调用 disable_commands() 时被清除）
- * 
- * 当 setup_actions > 0 时，驱动程序将重新设置所有动作，
- * 通过在其环境、兄弟对象和库存对象上调用 init()（按此顺序）。
- * @deprecated
- */
-void enable_commands(  );
 
 /**
  * enable_commands() - 允许对象使用“玩家”命令


### PR DESCRIPTION
- closes #244
- varargs version of efun will be used instead