### PR TITLE
lazily resolve return type of efuns access from inline closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   [macros named null are not resolving correctly #245](https://github.com/jlchmura/lpc-language-server/issues/245)
 -   [deprecation for enable_commands(void) may not be correct #244](https://github.com/jlchmura/lpc-language-server/issues/244)
 -   [Update documentation and hinting for origin() following merge of FluffOS PR #250](https://github.com/jlchmura/lpc-language-server/issues/250)
+-   [Efun signatures do not resolve their return type when access via inline closure #248](https://github.com/jlchmura/lpc-language-server/issues/248)
 
 ## 1.1.35
 

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -12548,7 +12548,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             // if an inline closure is set to a single identifier which is a function, use the resolved return type of that function
             if (isInlineClosureExpression(func) && isIdentifier(func.body) && getObjectFlags(returnType) & ObjectFlags.Anonymous) {
-                returnType = firstOrUndefined((returnType as ObjectType).callSignatures)?.resolvedReturnType ?? returnType;
+                const resolvedSig = getSingleCallSignature(returnType);
+
+                if (!resolvedSig.resolvedReturnType) {
+                    returnType = getReturnTypeOfSignature(resolvedSig) || returnType;
+                }                
+                else {
+                    returnType = resolvedSig.resolvedReturnType || returnType;
+                }
             }            
             
             // if (isAsync) {

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -178,6 +178,8 @@ exports[`Compiler compiler/closure6.c Reports correct errors for compiler/closur
 
 exports[`Compiler compiler/closure7.c Reports correct errors for compiler/closure7.c: diags-compiler/closure7.c 1`] = `""`;
 
+exports[`Compiler compiler/closure8.c Reports correct errors for compiler/closure8.c: diags-compiler/closure8.c 1`] = `""`;
+
 exports[`Compiler compiler/closureFuncShortcut1.c Reports correct errors for compiler/closureFuncShortcut1.c: diags-compiler/closureFuncShortcut1.c 1`] = `""`;
 
 exports[`Compiler compiler/closureFuncShortcut2.c Reports correct errors for compiler/closureFuncShortcut2.c: diags-compiler/closureFuncShortcut2.c 1`] = `

--- a/server/src/tests/cases/compiler/closure8.c
+++ b/server/src/tests/cases/compiler/closure8.c
@@ -1,0 +1,19 @@
+test() {
+    string *colors = ({ "red", "green", "blue" });
+    string *newColors;
+
+    newColors = map(colors, (: capitalize :));
+}
+
+/**
+ * This tests the return type of an inline closure set to do a identifier
+ * which resolves to a function.  In this case, the closure return type
+ * should be the same as the function (capitalize)
+ * 
+ * This test is similar to closure6 except that it uses an efun, which will 
+ * have lazy return type resolution.
+ * 
+ * Tests for https://github.com/jlchmura/lpc-language-server/issues/248
+ */
+
+// @driver: fluffos


### PR DESCRIPTION
- closes #248
- add unit test