### PR TITLE
make variadic types bivariadic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   [Property types are not checked when using new(class) syntax #263](https://github.com/jlchmura/lpc-language-server/issues/263)
 -   [Not getting hints when new()ing a class #260](https://github.com/jlchmura/lpc-language-server/issues/260)
 -   [FluffOS diagnostic incorrect about parameters not being read in lambda #258](https://github.com/jlchmura/lpc-language-server/issues/258)
+-   [LPCDoc variadic type indicator is on the wrong side #249](https://github.com/jlchmura/lpc-language-server/issues/249)
 
 ## 1.1.36
 

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -5640,7 +5640,8 @@ export namespace LpcParser {
         scanner.setSkipJsDocLeadingAsterisks(true);
         const pos = getPositionState();
         
-        const hasDotDotDot = parseOptional(SyntaxKind.DotDotDotToken);
+        // jsdoc variadic comes before
+        let hasDotDotDot = parseOptional(SyntaxKind.DotDotDotToken);
         let type = parseTypeOrTypePredicate();
 
         // support JS style array indicators (`arr[]`).. we are in jsdoc after all
@@ -5650,6 +5651,10 @@ export namespace LpcParser {
         }
 
         scanner.setSkipJsDocLeadingAsterisks(false);
+
+        // lpcdoc variadic comes after
+        hasDotDotDot ||= parseOptional(SyntaxKind.DotDotDotToken);
+
         if (hasDotDotDot) {            
             type = finishNode(factory.createJSDocVariadicType(type), pos);
         }

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -680,4 +680,8 @@ Found 1 error in server/src/tests/cases/compiler/varBeforeDecl2.c[90m:2[0m
 
 exports[`Compiler compiler/varBeforeDecl3.c Reports correct errors for compiler/varBeforeDecl3.c: diags-compiler/varBeforeDecl3.c 1`] = `""`;
 
+exports[`Compiler compiler/variadic1.c Reports correct errors for compiler/variadic1.c: diags-compiler/variadic1.c 1`] = `""`;
+
+exports[`Compiler compiler/variadic2.c Reports correct errors for compiler/variadic2.c: diags-compiler/variadic2.c 1`] = `""`;
+
 exports[`Compiler compiler/while1.c Reports correct errors for compiler/while1.c: diags-compiler/while1.c 1`] = `""`;

--- a/server/src/tests/cases/compiler/variadic1.c
+++ b/server/src/tests/cases/compiler/variadic1.c
@@ -1,0 +1,10 @@
+/**
+ * 
+ * @param {mixed...} args 
+ */
+test(args...) {
+    return args;
+}
+
+// should support lpcdoc-style variadic params
+// @driver: fluffos

--- a/server/src/tests/cases/compiler/variadic2.c
+++ b/server/src/tests/cases/compiler/variadic2.c
@@ -1,0 +1,10 @@
+/**
+ * 
+ * @param {...mixed} args 
+ */
+test(args...) {
+    return args;
+}
+
+// also support jsdoc-style variadic, because why not?
+// @driver: fluffos


### PR DESCRIPTION
- closes #249
- add unit tests for lpcdoc and jsdoc style variadic types