### PR TITLE
- allow stringized identifiers in expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LPC Language Services Changelog
 
+## 1.1.42
+
+-   [Hash operator in macros does not parse correctly #286](https://github.com/jlchmura/lpc-language-server/issues/286)
+
 ## 1.1.41
 
 -   Maintenance release - no user-facing changes.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lpc",
     "displayName": "LPC",
-    "version": "1.1.41",
+    "version": "1.1.42",
     "galleryBanner": {
         "color": "#000000",
         "theme": "dark"

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -3041,7 +3041,7 @@ export namespace LpcParser {
             return true;
         }
 
-        switch (token()) {
+        switch (token()) {            
             case SyntaxKind.PlusToken:
             case SyntaxKind.MinusToken:
             case SyntaxKind.TildeToken:
@@ -3052,6 +3052,7 @@ export namespace LpcParser {
             case SyntaxKind.PlusPlusToken:
             case SyntaxKind.MinusMinusToken:
             case SyntaxKind.LessThanToken:
+            case SyntaxKind.StringizedIdentifier:
             // case SyntaxKind.AwaitKeyword:
             // case SyntaxKind.YieldKeyword:
             // case SyntaxKind.PrivateIdentifier:            

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -628,6 +628,8 @@ Found 6 errors in the same file, starting at: server/src/tests/cases/compiler/st
 
 exports[`Compiler compiler/string2.c Reports correct errors for compiler/string2.c: diags-compiler/string2.c 1`] = `""`;
 
+exports[`Compiler compiler/stringizedIdentifier.c Reports correct errors for compiler/stringizedIdentifier.c: diags-compiler/stringizedIdentifier.c 1`] = `""`;
+
 exports[`Compiler compiler/struct1.c Reports correct errors for compiler/struct1.c: diags-compiler/struct1.c 1`] = `""`;
 
 exports[`Compiler compiler/struct2.c Reports correct errors for compiler/struct2.c: diags-compiler/struct2.c 1`] = `""`;

--- a/server/src/tests/cases/compiler/stringizedIdentifier.c
+++ b/server/src/tests/cases/compiler/stringizedIdentifier.c
@@ -1,0 +1,4 @@
+#define DEB(x) printf(#x ": %O\n", x)
+test() {
+  DEB("foo");
+}


### PR DESCRIPTION
- add unit test
- closes #286