### PR TITLE
Add restart commands for LPC Language Server and Syntax Server

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -199,6 +199,33 @@ export async function activate(context: ExtensionContext) {
         ]);
     }
     
+    async function restartClient(c: LanguageClient): Promise<void> {
+        // Temporarily suppress handleConnectionClosed to work around
+        // vscode-languageclient v8 bug that shows "Server will not be
+        // restarted" error during intentional stop/restart.
+        const origHandler = (c as any).handleConnectionClosed;
+        (c as any).handleConnectionClosed = async () => {};
+        try {
+            await c.stop();
+        } catch {
+            // Pending requests may be rejected during stop
+        } finally {
+            (c as any).handleConnectionClosed = origHandler;
+        }
+        await c.start();
+    }
+
+    context.subscriptions.push(
+        commands.registerCommand("lpc.restartLanguageServer", async () => {
+            window.showInformationMessage("Restarting LPC Language Server...");
+            await restartClient(client);
+        }),
+        commands.registerCommand("lpc.restartSyntaxServer", async () => {
+            window.showInformationMessage("Restarting LPC Syntax Server...");
+            await restartClient(syntaxClient);
+        })
+    );
+
     window.onDidChangeActiveTextEditor(async (editor) => {
         await getLpcConfigForActiveFile();
     });

--- a/package.json
+++ b/package.json
@@ -94,7 +94,16 @@
                 ]
             }
         ],
-        "commands": [],
+        "commands": [
+            {
+                "command": "lpc.restartLanguageServer",
+                "title": "LPC: Restart LPC Language Server"
+            },
+            {
+                "command": "lpc.restartSyntaxServer",
+                "title": "LPC: Restart LPC Syntax Server"
+            }
+        ],
         "taskDefinitions": [
             {
                 "type": "LPC",


### PR DESCRIPTION
Introduce commands to restart the LPC Language Server and Syntax Server, enhancing user control over server management. Update documentation to reflect these changes.