### PR TITLE
Add extra-args overloads for FluffOS sort_array

### DIFF
--- a/efuns/fluffos/arrays.h
+++ b/efuns/fluffos/arrays.h
@@ -61,10 +61,14 @@ varargs <mixed*>* unique_array(mixed *arr, function f, mixed skip );
  * 'ob->fun()'  will  be  passed  two  arguments for each call.  It should
  * return -1, 0, or 1, depending on the relationship of the two  arguments
  * (lesser, equal to, greater than).
- * 
+ *
  * The second form does the same thing but allows a function pointer to be
  * used instead.
- * 
+ *
+ * For the first and second forms, any additional arguments passed after the
+ * comparison function are forwarded to it on each call, appearing after the
+ * two elements being compared.
+ *
  * The third form returns an array with the same elements  as  'arr',  but
  * quicksorted using built-in sort routines.  A 'direction' of 1 or 0 will
  * quicksort in ascending order, while a 'direction' of -1 will  quicksort
@@ -76,8 +80,8 @@ varargs <mixed*>* unique_array(mixed *arr, function f, mixed skip );
  * @param {T} arr The array to sort
  * @returns {T} The sorted array
  */
-mixed *sort_array( mixed *arr, string fun, object ob );
-mixed *sort_array( mixed *arr, function f );
+mixed *sort_array( mixed *arr, string fun, object ob, mixed extra... );
+mixed *sort_array( mixed *arr, function f, mixed extra... );
 mixed *sort_array( mixed *arr, int direction );
 
 /**


### PR DESCRIPTION
## Summary

FluffOS `sort_array` forwards trailing arguments after the comparison function to it on each call — the same mechanism `map_array` and `filter_array` use, via `process_efun_callback`. The efun spec confirms it:

```c
// fluffos/src/packages/core/core.spec L222
mixed *sort_array(mixed *, int | string | function, ...);
```

The existing overloads in [efuns/fluffos/arrays.h](https://github.com/jlchmura/lpc-language-server/blob/main/efuns/fluffos/arrays.h#L79-L81) only declared the three base forms:

```c
mixed *sort_array( mixed *arr, string fun, object ob );
mixed *sort_array( mixed *arr, function f );
mixed *sort_array( mixed *arr, int direction );
```

…so callers passing extra context to the comparator hit a confusing diagnostic. For example:

```c
sort_array(room_names, function(string a, string b, mapping data) {
  return data[a].coords[0] - data[b].coords[0];
}, rooms);
```

…produces ``Argument of type 'object "__function"' is not assignable to parameter of type 'string'.`` because the only 3-arg overload the resolver sees is `(mixed*, string, object)`, so it tries to coerce the function literal to `string`.

This patch adds the `mixed extra...` variants for the function-pointer and string-method forms, matching the style already used for `map_array` and `filter_array` a few lines further down in the same file. The `int direction` overload correctly stays without varargs — the built-in sort doesn't take a comparator.

A companion fluffos PR updates the upstream FluffOS docs for `sort_array` to document the same behaviour.

## Test plan

- [x] Style matches existing `map_array`/`filter_array` declarations in the same file
- [ ] User code calling `sort_array(arr, fn, extra)` no longer reports a spurious diagnostic
- [ ] Existing 2- and 3-arg call sites still resolve