### PR TITLE
Add FluffOS mapping dot-access and optional chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LPC Language Services Changelog
 
+## 1.1.46
+
+- Enhancement: Add FluffOS mapping dot-access and optional chaining
+
 ## 1.1.45
 
 - Enhancement: Improve completion in closure expressions

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -2830,7 +2830,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }    
 
     function getOptionalExpressionType(exprType: Type, expression: Expression) {
-        console.debug("todo - getOptionalExpressionType");
+        // TODO: narrow away the short-circuited branch of an optional chain. When the base
+        // isn't a mapping the driver yields undefined (const0u) rather than erroring; until
+        // that's modelled, the chain's type is just the non-optional access type.
         return exprType;
         // TODO: 
         // return isExpressionOfOptionalChainRoot(expression) ? getNonNullableType(exprType) :
@@ -14849,6 +14851,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function checkElementAccessChain(node: ElementAccessChain, checkMode: CheckMode | undefined) {
         const exprType = checkExpression(node.expression);
         const nonOptionalType = getOptionalExpressionType(exprType, node.expression);
+        // FluffOS optional index `m?.[idx]` is mapping-only and short-circuits to undefined
+        // when the base isn't a mapping, so it never faults. Mappings resolve normally; any
+        // other (non-any) base returns mixed here instead of erroring on a bad index.
+        if (languageVariant === LanguageVariant.FluffOS && !isTypeAny(nonOptionalType) && !isMappingType(nonOptionalType)) {
+            checkExpression(node.argumentExpression);
+            return anyType;
+        }
         return propagateOptionalTypeMarker(checkElementAccessExpression(node, checkNonNullType(nonOptionalType, node.expression), checkMode), node, nonOptionalType !== exprType);
     }
 
@@ -24543,9 +24552,28 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         
         if (isParenthesizedExpression(right)) {
             // if right is a parenthesized expr, we can shortcut this whole check and just return any
-            // TODO - if right is a string literal - we can technically narrow validate the property access?            
+            // TODO - if right is a string literal - we can technically narrow validate the property access?
             const rigthExprType = checkExpression(right); // check the expression - but don't use its type
             return anyType;
+        }
+
+        // FluffOS mapping dot-access `m.key` is purely syntactic sugar for `m["key"]`,
+        // so it must resolve to the same type. Route through the same indexed-access
+        // machinery with the property name as a string-literal key; pass no access node so
+        // the resolver does a value lookup (yielding the mapping's value type, or mixed for
+        // an absent key / untyped mapping) instead of reporting a missing named property.
+        // Applies to `m?.key` too - the chain checker delegates here. Gated to FluffOS;
+        // LDMud, which has no mapping dot-access, falls through to normal member checking
+        // and rejects it.
+        const isOptionalAccess = !!(node.flags & NodeFlags.OptionalChain);
+        if (languageVariant === LanguageVariant.FluffOS && isMappingType(leftType)) {
+            const valueType = getIndexedAccessTypeOrUndefined(leftType, getStringLiteralType(right.text), AccessFlags.ExpressionPosition, /*accessNode*/ undefined) ?? anyType;
+            return getFlowTypeOfAccessExpression(node, /*prop*/ undefined, valueType, right, checkMode);
+        }
+        // Optional access `m?.key` on a non-mapping base short-circuits to undefined at
+        // runtime rather than erroring, so its type is just mixed (never a compile error).
+        if (languageVariant === LanguageVariant.FluffOS && isOptionalAccess) {
+            return getFlowTypeOfAccessExpression(node, /*prop*/ undefined, anyType, right, checkMode);
         }
 
         prop = getPropertyOfType(apparentType, right.text, /*skipObjectFunctionPropertyAugment*/ false, /*includeTypeOnlyMembers*/ node.kind === SyntaxKind.QualifiedName);

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -1,4 +1,4 @@
-import { AmpersandToken, ArrayLiteralExpression, ArrayTypeNode, BaseNodeFactory, BinaryExpression, BinaryOperatorToken, BindingPattern, Block, BooleanLiteral, BreakOrContinueStatement, BreakStatement, ByRefElement, CallExpression, CaseBlock, CaseClause, CaseOrDefaultClause, CastExpression, CatchExpression, CatchStatement, CharacterCodes, CloneObjectExpression, CommaListExpression, CommentRange, ConditionalExpression, ContinueStatement, Debug, DefaultClause, DefineDirective, Diagnostic, DiagnosticArguments, DiagnosticMessage, DiagnosticWithDetachedLocation, Diagnostics, DoWhileStatement, ElementAccessExpression, EndOfFileToken, EntityName, EvaluateExpression, Expression, ExpressionStatement, ExpressionWithTypeArguments, Extension, ForEachChildNodes, ForEachStatement, ForStatement, FunctionDeclaration, FunctionExpression, HasJSDoc, Identifier, IfStatement, ImpliedStringConcatExpression, ImportCandidateNode, IncludeDirective, InferTypeNode, InheritClauseNodeType, InheritDeclaration, InlineClosureExpression, IntersectionTypeNode, IterationStatement, JSDoc, JSDocAugmentsTag, JSDocAuthorTag, JSDocCallbackTag, JSDocClassTag, JSDocComment, JSDocDeprecatedTag, JSDocImplementsTag, JSDocLink, JSDocLinkCode, JSDocLinkPlain, JSDocMemberName, JSDocNameReference, JSDocOverloadTag, JSDocOverrideTag, JSDocParameterTag, JSDocParsingMode, JSDocPrivateTag, JSDocPropertyLikeTag, JSDocPropertyTag, JSDocProtectedTag, JSDocPublicTag, JSDocReturnTag, JSDocSatisfiesTag, JSDocSeeTag, JSDocSignature, JSDocSyntaxKind, JSDocTag, JSDocTemplateTag, JSDocText, JSDocThisTag, JSDocThrowsTag, JSDocTypeExpression, JSDocTypeLiteral, JSDocTypeTag, JSDocTypedefTag, JSDocUnknownTag, JSDocVariableTag, JSDocVariadicType, JsonMinusNumericLiteral, JsonObjectExpressionStatement, JsonSourceFile, KeywordSyntaxKind, LabeledStatement, LambdaExpression, LambdaIdentifierExpression, LambdaOperatorExpression, LambdaOperatorToken, LanguageVariant, LeftHandSideExpression, LiteralExpression, LiteralLikeNode, LiteralTypeNode, LpcFileHandler, LpcLoadImportResult, Macro, MacroParameter, MapLike, MappingEntryExpression, MappingLiteralExpression, MappingTypeNode, MemberExpression, MethodSignature, MissingDeclaration, Modifier, ModifierLike, Mutable, MutableNodeArray, NamedObjectTypeNode, NewExpression, NewExpressionArgument, NewStructExpression, Node, NodeArray, NodeFactory, NodeFactoryFlags, NodeFlags, NullLiteral, NumericLiteral, ObjectLiteralElementLike, ObjectLiteralExpression, OperatorPrecedence, ParameterDeclaration, ParenthesizedExpression, PositionState, PostfixUnaryExpression, PostfixUnaryOperator, PragmaContext, PragmaDefinition, PragmaDirective, PragmaKindFlags, PragmaMap, PragmaPseudoMap, PragmaPseudoMapEntry, PrefixUnaryExpression, PrefixUnaryOperator, PreprocessorDirective, PrimaryExpression, PropertyAccessEntityNameExpression, PropertyAccessExpression, PropertyAccessToken, PropertyAssignment, PropertyDeclaration, PropertyName, PropertySignature, PunctuationOrKeywordSyntaxKind, PunctuationSyntaxKind, QualifiedName, RangeExpression, RefToken, ResolutionMode, ReturnStatement, ScriptKind, ScriptTarget, ShorthandPropertyAssignment, SourceFile, SpreadElement, Statement, StringLiteral, StructDeclaration, StructTypeNode, SuperAccessExpression, SwitchStatement, SyntaxKind, Ternary, TextChangeRange, TextRange, Token, TupleTypeNode, TypeAssertion, TypeElement, TypeLiteralNode, TypeNode, TypeParameterDeclaration, TypePredicateNode, TypeReferenceNode, UnaryExpression, UndefDirective, UnionTypeNode, UpdateExpression, VariableDeclaration, VariableDeclarationList, VariableStatement, WhileStatement, addRange, addRelatedInfo, append, attachFileToDiagnostics, canHaveJSDoc, commentPragmas, concatenate, containsParseError, createDetachedDiagnostic, createNodeFactory, createScanner, emptyArray, emptyMap, fileExtensionIs, first, firstOrUndefined, flatten, forEach, forEachEntry, getAnyExtensionFromPath, getBaseFileName, getBinaryOperatorPrecedence, getDirectoryPath, getFullWidth, getJSDocCommentRanges, getLeadingCommentRanges, getSpellingSuggestion, idText, identity, isArray, isArrayTypeNode, isAssignmentOperator, isBinaryExpression, isIdentifier as isIdentifierNode, isIdentifierText, isJSDocReturnTag, isJSDocTypeTag, isKeyword, isKeywordOrPunctuation, isLeftHandSideExpression, isLiteralKind, isModifierKind, isNonReservedKeyword, isParenthesizedExpression, isStringLiteral, isStringOrNumericLiteralLike, isStructTypeNode, isTypeReferenceNode, last, lastOrUndefined, map, mapDefined, nodeIsMissing, nodeIsPresent, objectAllocator, performance, setNodeFlags, setParent, setParentRecursive, setTextRangePos, setTextRangePosEnd, setTextRangePosWidth, skipTrivia, some, startsWith, supportedDeclarationExtensions, textToKeywordObj, toArray, tokenIsIdentifierOrKeyword, tokenToString, tracing } from "./_namespaces/lpc";
+import { AmpersandToken, ArrayLiteralExpression, ArrayTypeNode, BaseNodeFactory, BinaryExpression, BinaryOperatorToken, BindingPattern, Block, BooleanLiteral, BreakOrContinueStatement, BreakStatement, ByRefElement, CallExpression, CaseBlock, CaseClause, CaseOrDefaultClause, CastExpression, CatchExpression, CatchStatement, CharacterCodes, CloneObjectExpression, CommaListExpression, CommentRange, ConditionalExpression, ContinueStatement, Debug, DefaultClause, DefineDirective, Diagnostic, DiagnosticArguments, DiagnosticMessage, DiagnosticWithDetachedLocation, Diagnostics, DoWhileStatement, ElementAccessExpression, EndOfFileToken, EntityName, EvaluateExpression, Expression, ExpressionStatement, ExpressionWithTypeArguments, Extension, ForEachChildNodes, ForEachStatement, ForStatement, FunctionDeclaration, FunctionExpression, HasJSDoc, Identifier, IfStatement, ImpliedStringConcatExpression, ImportCandidateNode, IncludeDirective, InferTypeNode, InheritClauseNodeType, InheritDeclaration, InlineClosureExpression, IntersectionTypeNode, IterationStatement, JSDoc, JSDocAugmentsTag, JSDocAuthorTag, JSDocCallbackTag, JSDocClassTag, JSDocComment, JSDocDeprecatedTag, JSDocImplementsTag, JSDocLink, JSDocLinkCode, JSDocLinkPlain, JSDocMemberName, JSDocNameReference, JSDocOverloadTag, JSDocOverrideTag, JSDocParameterTag, JSDocParsingMode, JSDocPrivateTag, JSDocPropertyLikeTag, JSDocPropertyTag, JSDocProtectedTag, JSDocPublicTag, JSDocReturnTag, JSDocSatisfiesTag, JSDocSeeTag, JSDocSignature, JSDocSyntaxKind, JSDocTag, JSDocTemplateTag, JSDocText, JSDocThisTag, JSDocThrowsTag, JSDocTypeExpression, JSDocTypeLiteral, JSDocTypeTag, JSDocTypedefTag, JSDocUnknownTag, JSDocVariableTag, JSDocVariadicType, JsonMinusNumericLiteral, JsonObjectExpressionStatement, JsonSourceFile, KeywordSyntaxKind, LabeledStatement, LambdaExpression, LambdaIdentifierExpression, LambdaOperatorExpression, LambdaOperatorToken, LanguageVariant, LeftHandSideExpression, LiteralExpression, LiteralLikeNode, LiteralTypeNode, LpcFileHandler, LpcLoadImportResult, Macro, MacroParameter, MapLike, MappingEntryExpression, MappingLiteralExpression, MappingTypeNode, MemberExpression, MethodSignature, MissingDeclaration, Modifier, ModifierLike, Mutable, MutableNodeArray, NamedObjectTypeNode, NewExpression, NewExpressionArgument, NewStructExpression, Node, NodeArray, NodeFactory, NodeFactoryFlags, NodeFlags, NullLiteral, NumericLiteral, ObjectLiteralElementLike, ObjectLiteralExpression, OperatorPrecedence, ParameterDeclaration, ParenthesizedExpression, PositionState, PostfixUnaryExpression, PostfixUnaryOperator, PragmaContext, PragmaDefinition, PragmaDirective, PragmaKindFlags, PragmaMap, PragmaPseudoMap, PragmaPseudoMapEntry, PrefixUnaryExpression, PrefixUnaryOperator, PreprocessorDirective, PrimaryExpression, PropertyAccessEntityNameExpression, PropertyAccessExpression, PropertyAccessToken, PropertyAssignment, PropertyDeclaration, PropertyName, PropertySignature, PunctuationOrKeywordSyntaxKind, PunctuationSyntaxKind, QualifiedName, QuestionDotToken, RangeExpression, RefToken, ResolutionMode, ReturnStatement, ScriptKind, ScriptTarget, ShorthandPropertyAssignment, SourceFile, SpreadElement, Statement, StringLiteral, StructDeclaration, StructTypeNode, SuperAccessExpression, SwitchStatement, SyntaxKind, Ternary, TextChangeRange, TextRange, Token, TupleTypeNode, TypeAssertion, TypeElement, TypeLiteralNode, TypeNode, TypeParameterDeclaration, TypePredicateNode, TypeReferenceNode, UnaryExpression, UndefDirective, UnionTypeNode, UpdateExpression, VariableDeclaration, VariableDeclarationList, VariableStatement, WhileStatement, addRange, addRelatedInfo, append, attachFileToDiagnostics, canHaveJSDoc, commentPragmas, concatenate, containsParseError, createDetachedDiagnostic, createNodeFactory, createScanner, emptyArray, emptyMap, fileExtensionIs, first, firstOrUndefined, flatten, forEach, forEachEntry, getAnyExtensionFromPath, getBaseFileName, getBinaryOperatorPrecedence, getDirectoryPath, getFullWidth, getJSDocCommentRanges, getLeadingCommentRanges, getSpellingSuggestion, idText, identity, isArray, isArrayTypeNode, isAssignmentOperator, isBinaryExpression, isIdentifier as isIdentifierNode, isIdentifierText, isJSDocReturnTag, isJSDocTypeTag, isKeyword, isKeywordOrPunctuation, isLeftHandSideExpression, isLiteralKind, isModifierKind, isNonReservedKeyword, isParenthesizedExpression, isStringLiteral, isStringOrNumericLiteralLike, isStructTypeNode, isTypeReferenceNode, last, lastOrUndefined, map, mapDefined, nodeIsMissing, nodeIsPresent, objectAllocator, performance, setNodeFlags, setParent, setParentRecursive, setTextRangePos, setTextRangePosEnd, setTextRangePosWidth, skipTrivia, some, startsWith, supportedDeclarationExtensions, textToKeywordObj, toArray, tokenIsIdentifierOrKeyword, tokenToString, tracing } from "./_namespaces/lpc";
 
 const enum SpeculationKind {
     TryParse,
@@ -4996,17 +4996,30 @@ export namespace LpcParser {
     }
 
     function parseMemberExpressionRest(pos: PositionState, expression: LeftHandSideExpression, allowOptionalChain: boolean): MemberExpression {
-        while (true) {   
+        while (true) {
             let isPropertyAccess = false;
-            let propertyAccessToken: Token<SyntaxKind.DotToken | SyntaxKind.MinusGreaterThanToken> | undefined;            
+            let propertyAccessToken: Token<SyntaxKind.DotToken | SyntaxKind.MinusGreaterThanToken> | undefined;
 
             if (token() == SyntaxKind.ColonColonToken) {
                 expression = parseSuperExpression(pos, expression)
             }
 
+            // FluffOS optional chaining: expr?.name (optional member) and expr?.[idx]
+            // (optional index), both lexed with a leading QuestionDotToken.
+            if (allowOptionalChain && token() === SyntaxKind.QuestionDotToken) {
+                const questionDotToken = parseTokenNode<QuestionDotToken>();
+                if (parseOptional(SyntaxKind.OpenBracketToken)) {
+                    expression = parseElementAccessExpressionRest(pos, expression, /*optionalChain*/ true);
+                }
+                else {
+                    expression = parsePropertyAccessExpressionRest(pos, expression, questionDotToken, /*optionalChain*/ true);
+                }
+                continue;
+            }
+
             if (token() == SyntaxKind.DotToken || token() == SyntaxKind.MinusGreaterThanToken) {
                 isPropertyAccess = true;
-                propertyAccessToken = parseTokenNode();                
+                propertyAccessToken = parseTokenNode();
             }
 
             if (isPropertyAccess) {
@@ -5014,14 +5027,14 @@ export namespace LpcParser {
                 continue;
             }
 
-            // handle implied string concatenation - consume all string literal nodes to the right            
+            // handle implied string concatenation - consume all string literal nodes to the right
             expression = tryParseImpliedStringConcatExpression(expression, pos);
-            
+
             if (parseOptional(SyntaxKind.OpenBracketToken)) {
                 expression = parseElementAccessExpressionRest(pos, expression);
                 continue;
             }
-                        
+
             return expression as MemberExpression;
         }
     }
@@ -5058,7 +5071,7 @@ export namespace LpcParser {
         return expression;
     }
 
-    function parseElementAccessExpressionRest(pos: PositionState, expression: LeftHandSideExpression) {
+    function parseElementAccessExpressionRest(pos: PositionState, expression: LeftHandSideExpression, optionalChain?: boolean) {
         let argumentExpression: Expression;
         if (token() === SyntaxKind.CloseBracketToken) {
             argumentExpression = createMissingNode(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ true, Diagnostics.An_element_access_expression_should_take_an_argument);
@@ -5091,10 +5104,15 @@ export namespace LpcParser {
         parseExpected(SyntaxKind.CloseBracketToken);
 
         const indexedAccess = factoryCreateElementAccessExpression(expression, argumentExpression);
+        if (optionalChain) {
+            // FluffOS optional element access (m?.[idx]); routes the checker to the
+            // mapping-optional chain path.
+            setNodeFlags(indexedAccess, indexedAccess.flags | NodeFlags.OptionalChain);
+        }
         return finishNode(indexedAccess, pos);
     }
 
-    function parsePropertyAccessExpressionRest(pos: PositionState, expression: LeftHandSideExpression, propertyAccessToken: PropertyAccessToken) {
+    function parsePropertyAccessExpressionRest(pos: PositionState, expression: LeftHandSideExpression, propertyAccessToken: PropertyAccessToken, optionalChain?: boolean) {
         let name: Expression | Identifier;
 
         if (token() === SyntaxKind.OpenParenToken) {
@@ -5103,9 +5121,13 @@ export namespace LpcParser {
             name = parseRightSideOfDot(/*allowIdentifierNames*/ true, /*allowPrivateIdentifiers*/ true, /*allowUnicodeEscapeSequenceInIdentifierName*/ true);
         }
 
-        const isOptionalChain = false;
         const propertyAccess = factoryCreatePropertyAccessExpression(expression, name, propertyAccessToken);
-        
+        if (optionalChain) {
+            // FluffOS optional member access (m?.key); routes the checker to the
+            // mapping-optional chain path.
+            setNodeFlags(propertyAccess, propertyAccess.flags | NodeFlags.OptionalChain);
+        }
+
         return addImportCandidate(finishNode(propertyAccess, pos));
     }
 

--- a/server/src/compiler/scanner.ts
+++ b/server/src/compiler/scanner.ts
@@ -2451,7 +2451,15 @@ export function createScanner(
                     return token = SyntaxKind.GreaterThanToken;
                 case CharacterCodes.question:
                     if (charCodeUnchecked(pos + 1) === CharacterCodes.dot && !isDigit(charCodeUnchecked(pos + 2))) {
-                        return pos += 2, token = SyntaxKind.QuestionDotToken;
+                        // FluffOS optional chaining "?." (mapping member/bracket access,
+                        // e.g. m?.key, m?.[idx]). Not matched before a digit so a ternary's
+                        // float branch ("cond ? .5 : x") still lexes as '?' then ".5".
+                        pos += 2;
+                        token = SyntaxKind.QuestionDotToken;
+                        if (languageVariant === LanguageVariant.LDMud) {
+                            error(Diagnostics.Operator_0_is_not_supported_in_LDMud, pos - 2, 2, "?.");
+                        }
+                        return token;
                     }
                     if (charCodeUnchecked(pos + 1) === CharacterCodes.question) {
                         if (charCodeUnchecked(pos + 2) === CharacterCodes.equals) {

--- a/server/src/compiler/types.ts
+++ b/server/src/compiler/types.ts
@@ -2632,10 +2632,13 @@ export type BarBarEqualsToken = PunctuationToken<SyntaxKind.BarBarEqualsToken>;
 export type AsteriskToken = PunctuationToken<SyntaxKind.AsteriskToken>;
 export type EqualsGreaterThanToken = PunctuationToken<SyntaxKind.EqualsGreaterThanToken>;
 export type MinusGreaterThanToken = PunctuationToken<SyntaxKind.MinusGreaterThanToken>;
+export type QuestionDotToken = PunctuationToken<SyntaxKind.QuestionDotToken>;
 export type PlusToken = PunctuationToken<SyntaxKind.PlusToken>;
 export type MinusToken = PunctuationToken<SyntaxKind.MinusToken>;
 
-export type PropertyAccessToken = DotToken | MinusGreaterThanToken;
+// QuestionDotToken records FluffOS optional chaining ("m?.key"); the node also
+// carries NodeFlags.OptionalChain to route the checker to the chain path.
+export type PropertyAccessToken = DotToken | MinusGreaterThanToken | QuestionDotToken;
 
 export type JSDocImportCandidateNode = 
     | JSDocParameterTag

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -536,6 +536,8 @@ Found 2 errors in the same file, starting at: server/src/tests/cases/compiler/ma
 
 exports[`Compiler compiler/mapping6.c Reports correct errors for compiler/mapping6.c: diags-compiler/mapping6.c 1`] = `""`;
 
+exports[`Compiler compiler/mappingDotAccess.c Reports correct errors for compiler/mappingDotAccess.c: diags-compiler/mappingDotAccess.c 1`] = `""`;
+
 exports[`Compiler compiler/mappingType1.c Reports correct errors for compiler/mappingType1.c: diags-compiler/mappingType1.c 1`] = `""`;
 
 exports[`Compiler compiler/mappingType2.c Reports correct errors for compiler/mappingType2.c: diags-compiler/mappingType2.c 1`] = `
@@ -632,6 +634,8 @@ exports[`Compiler compiler/operatorBitwise.c Reports correct errors for compiler
 exports[`Compiler compiler/operatorDoubleBang.c Reports correct errors for compiler/operatorDoubleBang.c: diags-compiler/operatorDoubleBang.c 1`] = `""`;
 
 exports[`Compiler compiler/operatorLogical.c Reports correct errors for compiler/operatorLogical.c: diags-compiler/operatorLogical.c 1`] = `""`;
+
+exports[`Compiler compiler/optionalChaining.c Reports correct errors for compiler/optionalChaining.c: diags-compiler/optionalChaining.c 1`] = `""`;
 
 exports[`Compiler compiler/paramRef.c Reports correct errors for compiler/paramRef.c: diags-compiler/paramRef.c 1`] = `""`;
 

--- a/server/src/tests/cases/compiler/mappingDotAccess.c
+++ b/server/src/tests/cases/compiler/mappingDotAccess.c
@@ -1,0 +1,22 @@
+// FluffOS mapping dot-access: `m.key` is sugar for `m["key"]`. Valid on
+// mappings only, resolves to the mapping's value type (mixed here), and -
+// unlike optional chaining - is a writable lvalue.
+
+mapping data = ([
+    "name": "Sup",
+    "nested": ([ "deep": 1 ]),
+]);
+
+void test() {
+    mixed a = data.name;              // dot-access
+    mixed b = data["name"];           // equivalent bracket form
+    mixed c = data.nested.deep;       // chained dot-access
+    mixed d = data.nested["deep"];    // dot then bracket
+    mixed e = data["nested"].deep;    // bracket then dot
+
+    data.name = "changed";            // dot-access is a valid lvalue
+    data.nested.deep = 2;
+}
+
+// @driver: fluffos
+// @errors: 0

--- a/server/src/tests/cases/compiler/optionalChaining.c
+++ b/server/src/tests/cases/compiler/optionalChaining.c
@@ -1,0 +1,19 @@
+// FluffOS optional chaining: `m?.key` (optional member) and `m?.[idx]`
+// (optional index). Mapping-only; when the base isn't a mapping the driver
+// short-circuits to undefined instead of erroring, so these never fault.
+
+mapping data = ([ "key": ([ "sub": 1 ]) ]);
+
+void test() {
+    mapping m;                          // uninitialized -> undefined base
+
+    mixed a = m?.key;                   // optional member on undefined base
+    mixed b = m?.["key"];               // optional index on undefined base
+
+    mixed c = data?.key?.sub;           // optional member chain
+    mixed d = data?.["key"]?.sub;       // optional index then optional member
+    mixed e = data.key?.missing?.deep;  // dot-access mixed with optional chain
+}
+
+// @driver: fluffos
+// @errors: 0

--- a/server/src/tests/optionalChaining.spec.ts
+++ b/server/src/tests/optionalChaining.spec.ts
@@ -1,0 +1,182 @@
+import * as lpc from "./_namespaces/lpc.js";
+import * as path from "path";
+
+/**
+ * Tests for two FluffOS access features:
+ *   - Mapping dot-access:  `m.key`  as sugar for  `m["key"]`.
+ *   - Optional chaining:   `m?.key` / `m?.[idx]`, mapping-only, short-circuiting
+ *     to undefined instead of erroring when the base isn't a mapping.
+ *
+ * Covers scanning/parsing (AST shape + the OptionalChain node flag), type
+ * inference through the checker, read-only enforcement of optional chains, and
+ * rejection of the syntax under non-FluffOS drivers.
+ */
+
+function parse(source: string, variant = lpc.LanguageVariant.FluffOS): lpc.SourceFile {
+    return lpc.createSourceFile("test.c", source, lpc.ScriptTarget.Latest, /*setParentNodes*/ true, lpc.ScriptKind.LPC, variant);
+}
+
+function collect<T extends lpc.Node>(root: lpc.Node, kind: lpc.SyntaxKind): T[] {
+    const out: T[] = [];
+    const walk = (n: lpc.Node): void => {
+        if (n.kind === kind) out.push(n as T);
+        lpc.forEachChild(n, walk);
+    };
+    walk(root);
+    return out;
+}
+
+const isOptionalChain = (n: lpc.Node) => !!(n.flags & lpc.NodeFlags.OptionalChain);
+
+describe("Mapping dot-access & optional chaining", () => {
+    describe("scanning & parsing", () => {
+        it("parses `m.key` as a plain (non-optional) property access", () => {
+            const sf = parse("void f() { mapping m = ([]); mixed r = m.key; }");
+            expect(sf.parseDiagnostics.length).toBe(0);
+            const access = collect<lpc.PropertyAccessExpression>(sf, lpc.SyntaxKind.PropertyAccessExpression);
+            expect(access.length).toBe(1);
+            expect(isOptionalChain(access[0])).toBe(false);
+            expect((access[0].name as lpc.Identifier).text).toBe("key");
+        });
+
+        it("parses `m?.key` as an optional property access", () => {
+            const sf = parse("void f() { mapping m = ([]); mixed r = m?.key; }");
+            expect(sf.parseDiagnostics.length).toBe(0);
+            const access = collect<lpc.PropertyAccessExpression>(sf, lpc.SyntaxKind.PropertyAccessExpression);
+            expect(access.length).toBe(1);
+            expect(isOptionalChain(access[0])).toBe(true);
+            expect((access[0].name as lpc.Identifier).text).toBe("key");
+        });
+
+        it("parses `m?.[idx]` as an optional element access", () => {
+            const sf = parse('void f() { mapping m = ([]); mixed r = m?.["k"]; }');
+            expect(sf.parseDiagnostics.length).toBe(0);
+            const access = collect<lpc.ElementAccessExpression>(sf, lpc.SyntaxKind.ElementAccessExpression);
+            expect(access.length).toBe(1);
+            expect(isOptionalChain(access[0])).toBe(true);
+        });
+
+        it("parses a nested optional chain `m?.a?.b`", () => {
+            const sf = parse("void f() { mapping m = ([]); mixed r = m?.a?.b; }");
+            expect(sf.parseDiagnostics.length).toBe(0);
+            const access = collect<lpc.PropertyAccessExpression>(sf, lpc.SyntaxKind.PropertyAccessExpression);
+            expect(access.length).toBe(2);
+            expect(access.every(isOptionalChain)).toBe(true);
+        });
+
+        it("does not steal from a ternary whose branch is a float (`c ? .5 : x`)", () => {
+            const sf = parse("void f() { float r = 1 ? .5 : 2.0; }");
+            expect(sf.parseDiagnostics.length).toBe(0);
+            expect(collect(sf, lpc.SyntaxKind.ConditionalExpression).length).toBe(1);
+            // No spurious optional-chain access nodes.
+            expect(collect(sf, lpc.SyntaxKind.PropertyAccessExpression).length).toBe(0);
+        });
+
+        it("does not steal from the nullish operator `??`", () => {
+            const sf = parse("void f() { mixed r = 0 ?? 1; }");
+            expect(sf.parseDiagnostics.length).toBe(0);
+            expect(collect(sf, lpc.SyntaxKind.PropertyAccessExpression).length).toBe(0);
+        });
+
+        it("rejects the dropped `.?[idx]` spelling as a syntax error", () => {
+            const sf = parse('void f() { mapping m = ([]); mixed r = m.?["k"]; }');
+            expect(sf.parseDiagnostics.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe("type inference", () => {
+        const root = process.cwd();
+
+        function checkSource(source: string, variant = lpc.LanguageVariant.FluffOS) {
+            const virtualFile = lpc.normalizeSlashes(path.join(root, "server/src/tests/cases/compiler/__optionalChainingProbe.c"));
+            const isVirtual = (fn: string) => !!fn && lpc.normalizeSlashes(fn) === virtualFile;
+            const compilerOptions: lpc.CompilerOptions = { driverType: variant, diagnostics: true };
+            const host = lpc.createCompilerHost(compilerOptions);
+            const origReadFile = host.readFile;
+            const origFileExists = host.fileExists;
+            host.readFile = (fn: string) => (isVirtual(fn) ? source : origReadFile.call(host, fn));
+            host.fileExists = (fn: string) => (isVirtual(fn) ? true : origFileExists.call(host, fn));
+            host.getDefaultLibFileName = () =>
+                lpc.combinePaths(root, lpc.getDefaultLibFolder(compilerOptions), lpc.getDefaultLibFileName(compilerOptions));
+
+            const program = lpc.createProgram({ host, rootNames: [virtualFile], options: compilerOptions, oldProgram: undefined });
+            const file = program.getSourceFile(virtualFile)!;
+            return { program, file, checker: program.getTypeChecker() };
+        }
+
+        function typeOfLastAccess(source: string) {
+            const { file, checker } = checkSource(source);
+            let access: lpc.Node | undefined;
+            const walk = (n: lpc.Node) => {
+                if (n.kind === lpc.SyntaxKind.PropertyAccessExpression || n.kind === lpc.SyntaxKind.ElementAccessExpression) access = n;
+                lpc.forEachChild(n, walk);
+            };
+            walk(file);
+            return checker.writeType(checker.getTypeAtLocation(access!));
+        }
+
+        it("infers `mixed` for mapping dot-access", () => {
+            expect(typeOfLastAccess("void f() { mapping m = ([]); mixed r = m.key; }")).toBe("mixed");
+        });
+
+        it("infers `mixed` for optional member and index access", () => {
+            expect(typeOfLastAccess("void f() { mapping m = ([]); mixed r = m?.key; }")).toBe("mixed");
+            expect(typeOfLastAccess('void f() { mapping m = ([]); mixed r = m?.["k"]; }')).toBe("mixed");
+        });
+
+        it("produces no diagnostics for dot-access and optional chains on mappings", () => {
+            const source =
+                "void f() {\n" +
+                "  mapping m = ([ \"k\": ([ \"sub\": 1 ]) ]);\n" +
+                "  mixed a = m.k;\n" +
+                "  mixed b = m?.k;\n" +
+                "  mixed c = m?.[\"k\"];\n" +
+                "  mixed d = m?.k?.sub;\n" +
+                "  mixed e = m.k?.missing?.deep;\n" +
+                "}";
+            const { program, file } = checkSource(source);
+            const diags = [...file.parseDiagnostics, ...program.getSemanticDiagnostics(file)];
+            expect(diags.length).toBe(0);
+        });
+
+        it("allows writing through mapping dot-access (`m.key = x`)", () => {
+            const { program, file } = checkSource("void f() { mapping m = ([]); m.key = 3; }");
+            const diags = [...file.parseDiagnostics, ...program.getSemanticDiagnostics(file)];
+            expect(diags.length).toBe(0);
+        });
+
+        it("forbids writing through an optional chain (`m?.key = x`)", () => {
+            const { program, file } = checkSource("void f() { mapping m = ([]); m?.key = 3; }");
+            const diags = [...file.parseDiagnostics, ...program.getSemanticDiagnostics(file)];
+            // The left-hand side of an assignment may not be an optional property access.
+            expect(diags.length).toBeGreaterThan(0);
+            expect(diags.some(d => typeof d.messageText === "string" && /optional/i.test(d.messageText))).toBe(true);
+        });
+    });
+
+    describe("non-FluffOS rejection", () => {
+        it("flags `?.` as unsupported under LDMud", () => {
+            const sf = parse("void f() { mapping m = ([]); mixed r = m?.key; }", lpc.LanguageVariant.LDMud);
+            expect(sf.parseDiagnostics.some(d => typeof d.messageText === "string" && /not supported in LDMud/i.test(d.messageText))).toBe(true);
+        });
+
+        it("does not silently accept mapping dot-access under LDMud", () => {
+            const root = process.cwd();
+            const virtualFile = lpc.normalizeSlashes(path.join(root, "server/src/tests/cases/compiler/__ldmudProbe.c"));
+            const isVirtual = (fn: string) => !!fn && lpc.normalizeSlashes(fn) === virtualFile;
+            const compilerOptions: lpc.CompilerOptions = { driverType: lpc.LanguageVariant.LDMud, diagnostics: true };
+            const host = lpc.createCompilerHost(compilerOptions);
+            const origReadFile = host.readFile;
+            const origFileExists = host.fileExists;
+            const source = "void f() { mapping m = ([]); mixed r = m.key; }";
+            host.readFile = (fn: string) => (isVirtual(fn) ? source : origReadFile.call(host, fn));
+            host.fileExists = (fn: string) => (isVirtual(fn) ? true : origFileExists.call(host, fn));
+            host.getDefaultLibFileName = () =>
+                lpc.combinePaths(root, lpc.getDefaultLibFolder(compilerOptions), lpc.getDefaultLibFileName(compilerOptions));
+            const program = lpc.createProgram({ host, rootNames: [virtualFile], options: compilerOptions, oldProgram: undefined });
+            const file = program.getSourceFile(virtualFile)!;
+            const diags = [...file.parseDiagnostics, ...program.getSemanticDiagnostics(file)];
+            expect(diags.length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/syntaxes/lpc.tmLanguage.json
+++ b/syntaxes/lpc.tmLanguage.json
@@ -647,6 +647,11 @@
         "operators": {
             "patterns": [
                 {
+                    "comment": "FluffOS optional chaining operator (m?.key, m?.[idx]). Negative lookahead keeps a ternary's float branch ('cond ? .5 : x') scoping as '?' then a numeric literal, matching the scanner.",
+                    "match": "\\?\\.(?![0-9])",
+                    "name": "keyword.operator.access.optional.lpc"
+                },
+                {
                     "match": "\\-\\-",
                     "name": "keyword.operator.decrement.lpc"
                 },


### PR DESCRIPTION
## Summary

Adds language-server support and TextMate highlighting for two mainline FluffOS language features (driver commit fluffos/fluffos@f79c309b, "Language: template literals, mapping dot access + optional chaining, %g"):

- **Mapping dot-access** — `m.key` as sugar for `m["key"]`. Infers the **same type** as the bracket form and is a writable lvalue.
- **Optional chaining** — `m?.key` and `m?.[idx]`, mapping-only and read-only, short-circuiting to undefined (rather than erroring) when the base isn't a mapping. Nested chains such as `m?.a?.b` are supported.

Both are gated to the FluffOS driver. LDMud continues to reject the syntax — a diagnostic for `?.`, and normal member-checking rejection for `m.key` on a mapping — so non-FluffOS drivers never silently accept it.

## Implementation

- **scanner** — emit an LDMud "not supported" diagnostic for `?.` (mirrors the existing `??` handling); `?.` was already tokenized as `QuestionDotToken`.
- **types** — widen `PropertyAccessToken` to include `QuestionDotToken`.
- **parser** — handle `QuestionDotToken` in `parseMemberExpressionRest`, building optional property/element accesses tagged with `NodeFlags.OptionalChain`. The existing chain-checker routing and the read-only-lvalue rule then apply automatically.
- **checker** — mapping dot-access routes through the same indexed-access resolution as element access (property name as a string-literal key, no access node), so `m.key` and `m["key"]` infer identically; optional access on a non-mapping base resolves to `mixed` instead of erroring.
- **grammar** — scope `?.` as `keyword.operator.access.optional.lpc`, verified with `vscode-textmate` (ternary `? .5`, `??`, and float literals are unaffected).

The obscure `.?[idx]` alternate spelling that also appears in the driver grammar is intentionally **not** supported — it's non-idiomatic and is treated as a syntax error here.

## Tests

- New compiler snapshot cases: `mappingDotAccess.c`, `optionalChaining.c` (both 0 errors).
- New inline spec `optionalChaining.spec.ts` (14 cases): AST shape + `OptionalChain` flag, `m.key` ≡ `m["key"]` type inference, deep chains, lvalue rules (`m.key = x` allowed, `m?.key = x` rejected), `.?` rejection, and non-FluffOS rejection.

Full suite: 738 passed, 241/241 snapshots pass. The 3 remaining failures pre-exist on `main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
