### PR TITLE
Fix: Infer nested-mapping value type in foreach instead of mixed*

### DIFF
--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -2543,8 +2543,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 });
             }
         }
-        popContextualType();     
-        
+        popContextualType();
         const finalKeyType = getReducedType(getUnionType(keyTypes, UnionReduction.Subtype));
         const finalElementTypes: Type = elementTypes.length > 1 ? createArrayType(getUnionType(elementTypes.map(types => getReducedType(getUnionType(types, UnionReduction.Subtype))))) :
             elementTypes.length === 1 ? getReducedType(getUnionType(elementTypes[0], UnionReduction.Subtype)) :
@@ -29711,8 +29710,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (node.initializer) {
             return getTypeOfInitializer(node.initializer);
         }        
-        if (node.parent.parent.kind === SyntaxKind.ForEachStatement) {            
-            return checkRightHandSideOfForEach(node.parent.parent) || errorType;
+        if (node.parent.parent.kind === SyntaxKind.ForEachStatement) {
+            const iteratedType = checkRightHandSideOfForEach(node.parent.parent) || errorType;
+            // For a foreach over a mapping, checkRightHandSideOfForEach returns a union of
+            // [keyType, valueType] so that the destructured key/value variables can be picked
+            // by their position in the declaration list. Extract this declaration's type instead
+            // of returning the whole union (which would otherwise flow into control-flow analysis
+            // and get widened to `mixed*`).
+            if (iteratedType.flags & TypeFlags.Union && node.parent.declarations.length > 1) {
+                const declIndex = node.parent.declarations.indexOf(node);
+                return (iteratedType as UnionType).types.at(declIndex) || iteratedType;
+            }
+            return iteratedType;
         }
         return errorType;
     }

--- a/server/src/tests/quickinfo.spec.ts
+++ b/server/src/tests/quickinfo.spec.ts
@@ -128,4 +128,27 @@ void test() {
         expect(declDisplay).toContain("int");
         expect(callDisplay).toContain("int");
     });
+
+    it("infers nested-mapping value type in foreach, not mixed*", () => {
+        // https://github.com/jlchmura/lpc-language-server/issues/319
+        const source = `mapping DIRECTIONS = ([
+  "north" : (["dz": 0, "dy": -1, "dx": 0]),
+]);
+
+void f() {
+  foreach(string k, mapping info in DIRECTIONS) {
+    info;
+  }
+}
+`;
+        const { ls, fileName } = createLanguageService(source);
+        const pos = source.indexOf("info;");
+        const display = getDisplayString(ls.getQuickInfoAtPosition(fileName, pos)!);
+        expect(display).toContain("mapping");
+        expect(display).not.toContain("mixed*");
+
+        // key variable should still infer as string
+        const kDisplay = getDisplayString(ls.getQuickInfoAtPosition(fileName, source.indexOf("k,"))!);
+        expect(kDisplay).toContain("string");
+    });
 });


### PR DESCRIPTION
## Fix: foreach over typed nested mapping infers value as `mixed*`

Fixes #319

### Problem

Iterating a mapping whose value type is itself a mapping produced `mixed*` for the destructured value variable:

```c
mapping DIRECTIONS = ([ "north" : (["dz": 0, "dy": -1, "dx": 0]) ]);

foreach(string k, mapping info in DIRECTIONS) {
    info;  // hover: mixed*  (expected: the inner mapping)
}
```

### Cause

The value-type *extraction* was actually correct — `getTypeForVariableLikeDeclaration` already indexes the `[keyType, valueType]` union by declaration position. The bug lived in a second, parallel path used by control-flow analysis:

`getInitialTypeOfVariableDeclaration` returned the entire `string | mapping` union as the loop variable's initial flow type instead of indexing it. That union then flowed into `getTypeAtFlowAssignment`, where `isTypeAssignableTo(string | mapping, mapping)` is `false` (a `string` isn't a `mapping`), so it fell back to `anyArrayType` — i.e. `mixed*`.

### Fix

`getInitialTypeOfVariableDeclaration` now indexes the iterated union by the variable's position in the foreach declaration list, mirroring the existing logic in `getTypeForVariableLikeDeclaration`. `info` now infers as the inner mapping and `k` remains `string`.

### Tests

- Added a regression test in `quickinfo.spec.ts` asserting `info` is `mapping` (not `mixed*`) and `k` is `string`.
- Full suite green: 779 passed.