### PR TITLE
Add set_clean_up() FluffOS efun definition

### DIFF
--- a/efuns/fluffos/system.h
+++ b/efuns/fluffos/system.h
@@ -419,3 +419,27 @@ object *all_previous_objects();
  *
  */
 varargs int request_clean_up( object ob );
+
+/**
+ * set_clean_up() - schedule when an object should next be queried for clean_up
+ *
+ * Schedules the driver's next clean_up() query on 'ob' for 'time' seconds
+ * from now, overriding the default idle-time rule (an object is normally
+ * queried once it has gone unreferenced for the 'time to clean up' config
+ * setting). The deadline is one-shot: after it fires, the object reverts to
+ * the idle-time rule.
+ *
+ * If 'time' is omitted, any pending explicit deadline is cancelled and the
+ * object reverts to the idle-time rule immediately.
+ *
+ * In both forms the object is re-flagged for clean_up consideration (like
+ * request_clean_up()), provided it defines a clean_up() apply. Objects
+ * without a clean_up() apply are never queried.
+ *
+ * Note that the sweep that performs clean_up queries runs every few minutes,
+ * so 'time' is a lower bound, not an exact firing time. If the 'time to
+ * clean up' config setting is 0, clean_up is disabled globally and explicit
+ * deadlines are ignored as well.
+ *
+ */
+varargs void set_clean_up( object ob, int time );


### PR DESCRIPTION
Adds a definition for the FluffOS `set_clean_up()` efun to `efuns/fluffos/system.h`, alongside the existing `request_clean_up()` entry.

```lpc
varargs void set_clean_up( object ob, int time );
```

**Semantics** (from the upstream fluffos efun): schedules the driver's next `clean_up()` query on `ob` for `time` seconds from now, overriding the default idle-time rule. The deadline is one-shot — after it fires, the object reverts to the idle-time rule. Omitting `time` cancels any pending deadline. In both forms the object is re-flagged for clean_up consideration (like `request_clean_up()`), provided it defines a `clean_up()` apply.

**Note:** the corresponding driver efun is fluffos PR #918 (`0c8cb37`), which is not yet merged into fluffos `master`/`dev` at the time of writing. The signature (`void set_clean_up(object, void | int)` in `core.spec`) is unlikely to change, so this is added ahead of the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)