### PR TITLE
Fix: respect explicit value-variable annotations in foreach loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 - Validate LPCDoc @param types and ref modifiers against signatures
 - Fix: Resolve inherit/object paths to .lpc files
 - Fix: Show return type on function declaration hover
-- Fix: [Infer nested-mapping value type in foreach instead of mixed*
-#325](https://github.com/jlchmura/lpc-language-server/issues/319)
+- Fix: [Infer nested-mapping value type in foreach instead of mixed\*
+  #319](https://github.com/jlchmura/lpc-language-server/issues/319)
+- Fix: [foreach: explicit type annotation on destructured value variable is validated then discarded #318](https://github.com/jlchmura/lpc-language-server/issues/318)
 
 ## 1.1.45
 

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -9436,6 +9436,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         if (!checkTypeAssignableToAndOptionallyElaborate(declType, declaredType, declaration, forEach.expression)) {
                             return errorType;
                         }
+                        // Respect the user's explicit annotation rather than discarding it in favor
+                        // of the inferred union element type (see #318).
+                        return declaredType;
                     }
 
                     return declType;

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -371,6 +371,8 @@ exports[`Compiler compiler/forEach10.c Reports correct errors for compiler/forEa
 
 exports[`Compiler compiler/forEach11.c Reports correct errors for compiler/forEach11.c: diags-compiler/forEach11.c 1`] = `""`;
 
+exports[`Compiler compiler/forEach12.c Reports correct errors for compiler/forEach12.c: diags-compiler/forEach12.c 1`] = `""`;
+
 exports[`Compiler compiler/forEachRef.c Reports correct errors for compiler/forEachRef.c: diags-compiler/forEachRef.c 1`] = `""`;
 
 exports[`Compiler compiler/forEachRef2.c Reports correct errors for compiler/forEachRef2.c: diags-compiler/forEachRef2.c 1`] = `""`;
@@ -455,6 +457,7 @@ Found 1 error in server/src/tests/cases/compiler/jsDocParam.c[90m:4[0m
 `;
 
 exports[`Compiler compiler/jsDocParamRef.c Reports correct errors for compiler/jsDocParamRef.c: diags-compiler/jsDocParamRef.c 1`] = `""`;
+
 exports[`Compiler compiler/jsDocParamRefMismatch.c Reports correct errors for compiler/jsDocParamRefMismatch.c: diags-compiler/jsDocParamRefMismatch.c 1`] = `
 "
 Found 2 errors in the same file, starting at: server/src/tests/cases/compiler/jsDocParamRefMismatch.c[90m:3[0m

--- a/server/src/tests/cases/compiler/forEach12.c
+++ b/server/src/tests/cases/compiler/forEach12.c
@@ -1,0 +1,24 @@
+/**
+ * @type {([ string: ([ string: int ]) ])}
+ */
+private nosave mapping DIRECTIONS = ([
+  "north" : (["dz": 0, "dy": -1, "dx": 0]),
+]);
+
+void f() {
+  mapping *directions = ({});
+  foreach(string dir, mapping info in DIRECTIONS) {
+    directions += ({ ([ "dir": dir ]) + info });
+  }
+}
+
+/**
+ * The explicit `mapping` annotation on the destructured value variable must be
+ * respected inside the loop body, so `info` is a mapping (not `mixed*`) and the
+ * `+` operator applies cleanly.
+ *
+ * https://github.com/jlchmura/lpc-language-server/issues/318
+ */
+
+// @driver: fluffos
+// @errors: 0

--- a/server/src/tests/quickinfo.spec.ts
+++ b/server/src/tests/quickinfo.spec.ts
@@ -151,4 +151,24 @@ void f() {
         const kDisplay = getDisplayString(ls.getQuickInfoAtPosition(fileName, source.indexOf("k,"))!);
         expect(kDisplay).toContain("string");
     });
+
+    it("respects an explicit value-variable annotation in a mapping foreach", () => {
+        // https://github.com/jlchmura/lpc-language-server/issues/318
+        // The mapping's inferred value type is a mapping, but the user explicitly
+        // annotates the destructured value as `mixed`. That annotation must win.
+        const source = `mapping DIRECTIONS = ([
+  "north" : (["dz": 0, "dy": -1, "dx": 0]),
+]);
+
+void f() {
+  foreach(string k, mixed info in DIRECTIONS) {
+  }
+}
+`;
+        const { ls, fileName } = createLanguageService(source);
+        const declPos = source.indexOf("info in");
+        const display = getDisplayString(ls.getQuickInfoAtPosition(fileName, declPos)!);
+        expect(display).toContain("mixed");
+        expect(display).not.toContain("mapping");
+    });
 });


### PR DESCRIPTION
## Fix: respect explicit type annotation on foreach destructured value variable

Fixes #318

### Problem

When a `foreach` destructures a mapping and the value variable carries an explicit type annotation, the annotation was validated for assignability and then thrown away — the inferred type was returned instead. Hovering on the variable at its declaration showed a different type than the annotation the user wrote.

```c
foreach(string k, mixed info in DIRECTIONS) { ... }
// hover on `info`: "mapping info"  (wrong — should honor the `mixed` annotation)
```

### Fix

In the mapping branch of `getTypeForVariableLikeDeclaration` ([[checker.ts:9434](https://claude.ai/epitaxy/server/src/compiler/checker.ts#L9434)](server/src/compiler/checker.ts#L9434)), return the validated `declaredType` when an annotation is present instead of falling through to the inferred union-element type.

### Relation to #319

Same code area, distinct bug. #319 (merged in #325) fixed the *inference* path so the value no longer comes out as `mixed*` — which removes the runtime error from #318's repro. This change fixes the *annotation* path so an explicit annotation is actually reflected in the declared type, which is still needed independently.

### Tests

- `quickinfo.spec.ts` — asserts an explicit `mixed` annotation on the value variable wins over the inferred mapping type. Confirmed to fail without the fix and pass with it.
- `forEach12.c` — end-to-end regression guard for the combined #318/#319 scenario (compiles with 0 errors).

Full suite: 789 passed, 250 snapshots passed.