### PR TITLE
Fix: `read_buffer` return typing + `buffer`/`bytes` type-name display (FluffOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Fix: [foreach: explicit type annotation on destructured value variable is validated then discarded #318](https://github.com/jlchmura/lpc-language-server/issues/318)
 - Fix: [trying to += the result of a function call to an array of an object
   #317](https://github.com/jlchmura/lpc-language-server/issues/317)
+- Fix: [incorrect data type being represented in diagnostic: bytes != buffer
+  #311](https://github.com/jlchmura/lpc-language-server/issues/311)
 
 ## 1.1.45
 

--- a/efuns/fluffos/buffers.h
+++ b/efuns/fluffos/buffers.h
@@ -34,9 +34,8 @@ a buffer as a string
  * runtime config file.
  *
  */
-string | buffer read_buffer( string | buffer src,
-                             int start,
-                             int len );
+buffer read_buffer( string src, void | int start, void | int len );
+string read_buffer( buffer src, void | int start, void | int len );
 
 /**
  * crc32() - compute the cycle redundancy code for a buffer or string

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -19914,6 +19914,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword);
             }
             if (type.flags & TypeFlags.Bytes) {
+                // The same intrinsic type is spelled `buffer` in FluffOS and `bytes` in LDMud.
+                // Render it using the driver-appropriate keyword (see #311).
+                if (languageVariant === LanguageVariant.FluffOS) {
+                    context.approximateLength += 6;
+                    return factory.createKeywordTypeNode(SyntaxKind.BufferKeyword);
+                }
                 context.approximateLength += 5;
                 return factory.createKeywordTypeNode(SyntaxKind.BytesKeyword);
             }

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -685,6 +685,8 @@ Found 1 error in server/src/tests/cases/compiler/preproc_conditional_macro.c[90
 "
 `;
 
+exports[`Compiler compiler/readBuffer1.c Reports correct errors for compiler/readBuffer1.c: diags-compiler/readBuffer1.c 1`] = `""`;
+
 exports[`Compiler compiler/return1.c Reports correct errors for compiler/return1.c: diags-compiler/return1.c 1`] = `""`;
 
 exports[`Compiler compiler/string1.c Reports correct errors for compiler/string1.c: diags-compiler/string1.c 1`] = `

--- a/server/src/tests/bufferType.spec.ts
+++ b/server/src/tests/bufferType.spec.ts
@@ -1,0 +1,53 @@
+import * as lpc from "./_namespaces/lpc.js";
+import * as path from "path";
+
+/**
+ * The byte-buffer intrinsic is one type with two driver-specific spellings:
+ * `buffer` in FluffOS and `bytes` in LDMud. Diagnostics and hovers must render
+ * it with the name that matches the active driver.
+ *
+ * https://github.com/jlchmura/lpc-language-server/issues/311
+ */
+
+function diagnosticsFor(source: string, driverType: lpc.LanguageVariant): lpc.Diagnostic[] {
+    const root = process.cwd();
+    const virtualFile = lpc.normalizeSlashes(path.join(root, "server/src/tests/cases/compiler/__bufferProbe.c"));
+    const isVirtual = (fn: string) => !!fn && lpc.normalizeSlashes(fn) === virtualFile;
+
+    const compilerOptions: lpc.CompilerOptions = { driverType, diagnostics: true };
+    const host = lpc.createCompilerHost(compilerOptions);
+    const origReadFile = host.readFile;
+    const origFileExists = host.fileExists;
+    host.readFile = (fn: string) => (isVirtual(fn) ? source : origReadFile.call(host, fn));
+    host.fileExists = (fn: string) => (isVirtual(fn) ? true : origFileExists.call(host, fn));
+    host.getDefaultLibFileName = () =>
+        lpc.combinePaths(root, lpc.getDefaultLibFolder(compilerOptions), lpc.getDefaultLibFileName(compilerOptions));
+
+    const program = lpc.createProgram({ host, rootNames: [virtualFile], options: compilerOptions, oldProgram: undefined });
+    const file = program.getSourceFile(virtualFile)!;
+    return [...file.parseDiagnostics, ...program.getSemanticDiagnostics(file)];
+}
+
+function messages(diags: lpc.Diagnostic[]): string {
+    return diags.map(d => lpc.flattenDiagnosticMessageText(d.messageText, "\n")).join("\n");
+}
+
+describe("buffer/bytes type naming (#311)", () => {
+    // Assigning `string | buffer` to a `buffer` is a genuine error (the `string`
+    // constituent isn't assignable), so the diagnostic exercises how the type is named.
+    const source = "string | buffer read_thing(string src);\nvoid test() { buffer b = read_thing(\"x\"); }";
+
+    it("names the type `buffer` under FluffOS", () => {
+        const text = messages(diagnosticsFor(source, lpc.LanguageVariant.FluffOS));
+        expect(text).toContain("buffer");
+        expect(text).not.toContain("bytes");
+    });
+
+    it("names the type `bytes` under LDMud", () => {
+        // `bytes` is the LDMud spelling of the same intrinsic.
+        const ldSource = "string | bytes read_thing(string src);\nvoid test() { bytes b = read_thing(\"x\"); }";
+        const text = messages(diagnosticsFor(ldSource, lpc.LanguageVariant.LDMud));
+        expect(text).toContain("bytes");
+        expect(text).not.toContain("buffer");
+    });
+});

--- a/server/src/tests/cases/compiler/readBuffer1.c
+++ b/server/src/tests/cases/compiler/readBuffer1.c
@@ -1,0 +1,15 @@
+// read_buffer(): a string (filename) source yields a buffer; a buffer source
+// yields a string. https://github.com/jlchmura/lpc-language-server/issues/311
+
+void test(string file, buffer buf) {
+    buffer contents = read_buffer(file, 0, file_size(file));
+    string part = read_buffer(buf, 0, 10);
+    string whole = read_buffer(buf);
+
+    contents = allocate_buffer(1);
+    part = "x";
+    whole = "y";
+}
+
+// @driver: fluffos
+// @errors: 0


### PR DESCRIPTION
Fixes #311

### Problem

Two issues, both visible in the reported `integrity_check` example:

1. **Wrong type name.** `buffer` (FluffOS) and `bytes` (LDMud) are two driver-specific spellings of the *same* intrinsic type, but diagnostics/hovers always rendered it as `bytes` — so a FluffOS user saw `string | bytes` for code that only ever mentions `buffer`.

2. **Wrong `read_buffer` signature.** The efun was typed as a single overload returning `string | buffer`, so `buffer x = read_buffer(file, ...)` was flagged (`Type 'string | buffer' is not assignable to type 'buffer'`) — the false error in the screenshot. But the efun's own docs say the return type depends on the source: *"read from a file and return a **buffer**, or return part of a buffer as a **string**."*

### Fix

- **`checker.ts`** — render the byte-buffer intrinsic with the driver-appropriate keyword (`buffer` under FluffOS, `bytes` otherwise), mirroring the existing `closure`/`function` precedent.
- **`efuns/fluffos/buffers.h`** — split `read_buffer` into two overloads (the established multi-prototype pattern), and make `start`/`len` optional per the docs:
  ```lpc
  buffer read_buffer( string src, void | int start, void | int len );  // filename → buffer
  string read_buffer( buffer src, void | int start, void | int len );  // buffer  → string
  ```

Now `buffer x = read_buffer(filename, ...)` resolves to the string-source overload and returns `buffer` with no cast or narrowing.

### Tests

- `bufferType.spec.ts` — asserts diagnostics name the type `buffer` under FluffOS and `bytes` under LDMud (fails without the display fix).
- `cases/compiler/readBuffer1.c` — string source → `buffer`, buffer source → `string`, 0 errors (fails on the old union typing).

Full suite green (797 tests). Note: `lib/src/efuns/...` is a gitignored build copy, so only the source header was edited.