### PR TITLE
Fix: report assignment to an undeclared variable under FluffOS

### DIFF
--- a/schemas/lpc.schema.json
+++ b/schemas/lpc.schema.json
@@ -18,6 +18,9 @@
             "$ref": "#/definitions/driverDefinition"
         },
         {
+            "$ref": "#/definitions/allowUndeclaredAssignmentsInLdDefinition"
+        },
+        {
             "$ref": "#/definitions/diagnosticsDefinition"
         },
         {
@@ -72,6 +75,15 @@
                             "default": false
                         }
                     }
+                }
+            }
+        },
+        "allowUndeclaredAssignmentsInLdDefinition": {
+            "properties": {
+                "allowUndeclaredAssignmentsInLd": {
+                    "description": "LDMud only. When true (the default), assigning to an undeclared variable implicitly declares it, since LDMud makes types optional. Set to false to report the assignment target as an unresolved name instead, matching FluffOS, where assigning to an undeclared variable is illegal. Has no effect under FluffOS.",
+                    "type": "boolean",
+                    "default": true
                 }
             }
         },

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -22274,19 +22274,24 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const name = isString(nameArg) ? nameArg : (nameArg as Identifier).text;
 
         if (errorLocation?.parent && isAssignmentExpression(errorLocation.parent) && errorLocation.parent.left === nameArg) {
-            const nodeToBind = errorLocation.parent;
-            // if we didn't find a symbol and original location was an assignment expression, and pragma strict types is not on
-            // then we treat the first instance as a variable declaration and create a symbol for it
-            
-            // if (!isStrictCompilerOptionEnabled(compilerOptions, "strictTypes")) {
-            const container = getEnclosingLocalsContainer(errorLocation.parent);
-            if (!container.locals) container.locals = createSymbolTable();
+            // Assigning to an undeclared variable: LDMud treats the first assignment as an
+            // implicit declaration (types are optional there), so we synthesize a symbol for it.
+            // FluffOS forbids this, and LDMud projects can opt into the same strictness by
+            // setting `allowUndeclaredAssignmentsInLd: false`. In those cases we fall through to
+            // report the name as unresolved.
+            const allowImplicitDeclaration = languageVariant === LanguageVariant.LDMud &&
+                compilerOptions.allowUndeclaredAssignmentsInLd !== false;
+            if (allowImplicitDeclaration) {
+                const nodeToBind = errorLocation.parent;
+                const container = getEnclosingLocalsContainer(errorLocation.parent);
+                if (!container.locals) container.locals = createSymbolTable();
 
-            const containerSymbol = getSymbolOfNode(container);
-            const symbol = lateBindBinaryExpressionDeclaration(container.locals, containerSymbol, nodeToBind, SymbolFlags.Variable, SymbolFlags.None);
-            
-            return symbol;
-        } 
+                const containerSymbol = getSymbolOfNode(container);
+                const symbol = lateBindBinaryExpressionDeclaration(container.locals, containerSymbol, nodeToBind, SymbolFlags.Variable, SymbolFlags.None);
+
+                return symbol;
+            }
+        }
 
         addLazyDiagnostic(() => {
             if (

--- a/server/src/compiler/commandLineParser.ts
+++ b/server/src/compiler/commandLineParser.ts
@@ -261,7 +261,12 @@ function parseLpcConfigFileContentWorker(
     }
 
     options.diagnostics = raw?.diagnostics === "on" || raw?.diagnostics === true;
-    
+
+    // LDMud allows assigning to an undeclared variable (types are optional). Default to
+    // preserving that behavior; a project can set this false to opt into FluffOS-style
+    // "cannot find name" errors for undeclared assignment targets.
+    options.allowUndeclaredAssignmentsInLd = raw?.allowUndeclaredAssignmentsInLd !== false;
+
     const sefunFilePath = trimStart(options.sefunFile ?? raw?.libFiles?.simul_efun ?? "/obj/sefun.c", "/");
     options.sefunFile = normalizePath(combinePaths(libRootPath, sefunFilePath));
 

--- a/server/src/compiler/types.ts
+++ b/server/src/compiler/types.ts
@@ -1752,6 +1752,14 @@ export interface CompilerOptions {
     getCompilationSettings?: any;
     configFilePath?: string;
     driverType?: LanguageVariant;
+    /**
+     * LDMud only. When true (the default), assigning to an undeclared variable
+     * implicitly declares it (LDMud allows this because types are optional). Set
+     * to false to instead report the assignment target as an unresolved name,
+     * matching FluffOS, where assigning to an undeclared variable is illegal.
+     * Has no effect under FluffOS, which always reports the error.
+     */
+    allowUndeclaredAssignmentsInLd?: boolean;
     rootDir?: string;
     rootDirs?: string[];
     outDir?: string;

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -767,6 +767,15 @@ exports[`Compiler compiler/typePredicate2.c Reports correct errors for compiler/
 
 exports[`Compiler compiler/typePredicate3.c Reports correct errors for compiler/typePredicate3.c: diags-compiler/typePredicate3.c 1`] = `""`;
 
+exports[`Compiler compiler/undeclaredAssignmentFluffos.c Reports correct errors for compiler/undeclaredAssignmentFluffos.c: diags-compiler/undeclaredAssignmentFluffos.c 1`] = `
+"
+Found 1 error in server/src/tests/cases/compiler/undeclaredAssignmentFluffos.c[90m:5[0m
+
+"
+`;
+
+exports[`Compiler compiler/undeclaredAssignmentLdmud.c Reports correct errors for compiler/undeclaredAssignmentLdmud.c: diags-compiler/undeclaredAssignmentLdmud.c 1`] = `""`;
+
 exports[`Compiler compiler/unionTypes.c Reports correct errors for compiler/unionTypes.c: diags-compiler/unionTypes.c 1`] = `""`;
 
 exports[`Compiler compiler/utf8.c Reports correct errors for compiler/utf8.c: diags-compiler/utf8.c 1`] = `""`;

--- a/server/src/tests/cases/compiler/class1.c
+++ b/server/src/tests/cases/compiler/class1.c
@@ -5,5 +5,5 @@ class Test {
 }
 
 test() {
-    foo = new(class Test);
+    mixed foo = new(class Test);
 }

--- a/server/src/tests/cases/compiler/intLiteral2.c
+++ b/server/src/tests/cases/compiler/intLiteral2.c
@@ -1,5 +1,6 @@
 // @driver: fluffos
 test2() {
+    mixed x;
     x = 1234567890123456;
     x =0x462d53c8abac0;
     x = 0xCAFEBABE;

--- a/server/src/tests/cases/compiler/undeclaredAssignmentFluffos.c
+++ b/server/src/tests/cases/compiler/undeclaredAssignmentFluffos.c
@@ -1,0 +1,9 @@
+// Under FluffOS, assigning to an undeclared variable is illegal: the assignment
+// target does not implicitly declare a variable, so it is reported as an
+// unresolved name. Counterpart to undeclaredAssignmentLdmud.c.
+void f() {
+    foo = 1;
+}
+
+// @driver: fluffos
+// @errors: 1

--- a/server/src/tests/cases/compiler/undeclaredAssignmentLdmud.c
+++ b/server/src/tests/cases/compiler/undeclaredAssignmentLdmud.c
@@ -1,0 +1,10 @@
+// Under LDMud, types are optional, so assigning to an undeclared variable
+// implicitly declares it and produces no diagnostic (the default behavior,
+// gated by allowUndeclaredAssignmentsInLd). Counterpart to
+// undeclaredAssignmentFluffos.c.
+void f() {
+    foo = 1;
+}
+
+// @driver: ldmud
+// @errors: 0

--- a/server/src/tests/undeclaredAssignment.spec.ts
+++ b/server/src/tests/undeclaredAssignment.spec.ts
@@ -1,0 +1,90 @@
+import * as lpc from "./_namespaces/lpc.js";
+import * as path from "path";
+
+/**
+ * Assigning to an undeclared variable.
+ *
+ * LDMud makes types optional, so `foo = 1` with no prior declaration is legal:
+ * the first assignment implicitly declares the variable. FluffOS forbids this and
+ * reports the target as an unresolved name. LDMud projects can opt into the same
+ * strictness with the `allowUndeclaredAssignmentsInLd: false` compiler option.
+ */
+function createLanguageService(options: lpc.CompilerOptions, fileText: Record<string, string>) {
+    const cwd = lpc.normalizePath(process.cwd());
+    const toAbs = (rel: string) => lpc.normalizePath(path.join(cwd, rel));
+
+    const files = new Map<string, string>();
+    for (const rel of Object.keys(fileText)) files.set(toAbs(rel), fileText[rel]);
+
+    const scriptFiles = Array.from(files.keys());
+    const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
+    const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
+    const norm = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
+
+    const host: lpc.LanguageServiceHost = {
+        getCompilationSettings: () => options,
+        getCurrentDirectory: () => cwd,
+        getDefaultLibFileName: (opts) =>
+            lpc.combinePaths(cwd, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
+        getIncludeDirs: () => [],
+        getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, cwd, getCanonicalFileName))),
+        getScriptFileNames: () => scriptFiles,
+        getScriptSnapshot: (name) => {
+            const n = norm(name);
+            if (!n) return undefined;
+            const text = files.get(n) ?? lpc.sys.readFile(n);
+            return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
+        },
+        getScriptVersion: () => "1",
+        isKnownTypesPackageName: () => false,
+        useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
+        fileExists: (name) => { const n = norm(name); return !!n && (files.has(n) || lpc.sys.fileExists(n)); },
+        readFile: (name) => { const n = norm(name); return n ? files.get(n) ?? lpc.sys.readFile(n) : undefined; },
+        onAllFilesNeedReparse: () => undefined,
+        onReleaseOldSourceFile: () => undefined,
+        onReleaseParsedCommandLine: () => undefined,
+    };
+
+    const fileHandler = lpc.createLpcFileHandler({
+        fileExists: (name) => host.fileExists(name),
+        readFile: (name) => host.readFile(name),
+        getIncludeDirs: () => host.getIncludeDirs(),
+        getCompilerOptions: () => host.getCompilationSettings(),
+        getCurrentDirectory: () => host.getCurrentDirectory(),
+    });
+
+    return { ls: lpc.createLanguageService(host, fileHandler), abs: toAbs };
+}
+
+const source = `void f() {\n    foo = 1;\n}\n`;
+
+function messagesFor(options: lpc.CompilerOptions): string[] {
+    const { ls, abs } = createLanguageService(options, { "test.c": source });
+    return ls.getSemanticDiagnostics(abs("test.c"))
+        .map(d => lpc.flattenDiagnosticMessageText(d.messageText, "\n"));
+}
+
+describe("assignment to an undeclared variable", () => {
+    it("is allowed under LDMud by default (implicit declaration)", () => {
+        const msgs = messagesFor({ driverType: lpc.LanguageVariant.LDMud, diagnostics: true });
+        expect(msgs.filter(m => m.includes("Cannot find name"))).toEqual([]);
+    });
+
+    it("is an unresolved name under LDMud when allowUndeclaredAssignmentsInLd is false", () => {
+        const msgs = messagesFor({
+            driverType: lpc.LanguageVariant.LDMud,
+            diagnostics: true,
+            allowUndeclaredAssignmentsInLd: false,
+        });
+        expect(msgs.some(m => m.includes("Cannot find name 'foo'"))).toBe(true);
+    });
+
+    it("is an unresolved name under FluffOS regardless of the option", () => {
+        const msgs = messagesFor({
+            driverType: lpc.LanguageVariant.FluffOS,
+            diagnostics: true,
+            allowUndeclaredAssignmentsInLd: true,
+        });
+        expect(msgs.some(m => m.includes("Cannot find name 'foo'"))).toBe(true);
+    });
+});


### PR DESCRIPTION
## Problem

FluffOS forbids assigning to an undeclared variable, but the checker treated the first assignment as an implicit declaration for **every** driver. So under FluffOS, `foo = 1;` with no prior declaration was silently accepted instead of reported.

## Fix

Gate the implicit-declaration behavior on the driver (`onFailedToResolveSymbol` in `checker.ts`):

- **FluffOS** — an undeclared assignment target is now reported as an unresolved name (`Cannot find name 'x'`).
- **LDMud** — keeps implicit declaration, since types are optional there (`foo = 1` is legal).
- New **`allowUndeclaredAssignmentsInLd`** lpc-config option (default `true`) lets LDMud projects opt into the stricter, FluffOS-style behavior.

## Notes

The FluffOS fixtures `class1.c` and `intLiteral2.c` used undeclared assignment targets purely as scratch variables and only passed because of the old behavior. Their intent is testing `new(class ...)` syntax and integer literals, so their scratch variables are now given explicit declarations.

## Tests

- `undeclaredAssignmentFluffos.c` (errors) / `undeclaredAssignmentLdmud.c` (clean by default)
- `undeclaredAssignment.spec.ts` covering LDMud-default, LDMud-strict (option `false`), and FluffOS

Full suite passes; `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)