### PR TITLE
Fix: rename/find-references scopes file-global variables to their file (and inheritors)

### DIFF
--- a/server/src/services/findAllReferences.ts
+++ b/server/src/services/findAllReferences.ts
@@ -1490,10 +1490,16 @@ export namespace Core {
         if (!relatedSymbol) {
             if (getReferenceForShorthandProperty(referenceSymbol, search, state)) {
                 return;
-            } else {
-                // I had to add this in to get object-level variables to show up 
-                // as references
+            } else if (sharesDeclarationWithSearch(referenceSymbol, search)) {
+                // The checker can mint distinct Symbol objects that nonetheless
+                // share the same declaration node (this happens for object-level
+                // / file-global variables). Identity comparison in `search.includes`
+                // misses these, so fall back to matching on a shared declaration.
+                // This keeps same-file (and inherited) references showing up while
+                // excluding same-named globals declared in unrelated files.
                 relatedSymbol = { symbol: referenceSymbol, kind: EntryKind.Node };
+            } else {
+                return;
             }
         }
 
@@ -2248,6 +2254,23 @@ export namespace Core {
         if (!symbol.valueDeclaration) return false;
         const modifierFlags = getEffectiveModifierFlags(symbol.valueDeclaration);
         return !!(modifierFlags & ModifierFlags.Static);
+    }
+
+    /**
+     * True when `referenceSymbol` shares at least one declaration node with a
+     * symbol in the search set. LPC's checker can produce several distinct
+     * `Symbol` objects for the same file-global (object-level) variable, so
+     * identity comparison (`search.includes`) is not enough to recognize a
+     * legitimate reference. Matching on a shared declaration recognizes those
+     * references (and inherited ones, which resolve to the inherited
+     * declaration) while rejecting same-named globals from unrelated files,
+     * which have their own declarations.
+     */
+    function sharesDeclarationWithSearch(referenceSymbol: Symbol, search: Search): boolean {
+        const refDeclarations = referenceSymbol.declarations;
+        if (!refDeclarations || refDeclarations.length === 0) return false;
+        return search.allSearchSymbols.some(searchSymbol =>
+            searchSymbol.declarations?.some(decl => contains(refDeclarations, decl)));
     }
 
     function getRelatedSymbol(search: Search, referenceSymbol: Symbol, referenceLocation: Node, state: State): RelatedSymbol | undefined {

--- a/server/src/tests/renameGlobalVarScope.spec.ts
+++ b/server/src/tests/renameGlobalVarScope.spec.ts
@@ -1,0 +1,131 @@
+import * as lpc from "./_namespaces/lpc.js";
+import * as path from "path";
+
+function makeLanguageService(files: Map<string, string>) {
+    const options: lpc.CompilerOptions = {
+        driverType: lpc.LanguageVariant.FluffOS,
+        diagnostics: true,
+    };
+
+    const scriptFiles = [...files.keys()];
+    const scriptVersions = new Map<string, string>(scriptFiles.map((f) => [f, "1"]));
+
+    const currentDirectory = lpc.normalizePath(process.cwd());
+    const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
+    const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
+    const normalizeHostFileName = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
+
+    const host: lpc.LanguageServiceHost = {
+        getCompilationSettings: () => options,
+        getCurrentDirectory: () => currentDirectory,
+        getDefaultLibFileName: (opts) =>
+            lpc.combinePaths(currentDirectory, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
+        getIncludeDirs: () => [],
+        getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, currentDirectory, getCanonicalFileName))),
+        getScriptFileNames: () => scriptFiles,
+        getScriptSnapshot: (name) => {
+            const normalizedName = normalizeHostFileName(name);
+            if (!normalizedName) return undefined;
+            const text = files.get(normalizedName) ?? lpc.sys.readFile(normalizedName);
+            return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
+        },
+        getScriptVersion: (name) => {
+            const normalizedName = normalizeHostFileName(name);
+            return normalizedName ? scriptVersions.get(normalizedName) ?? "0" : "0";
+        },
+        isKnownTypesPackageName: () => false,
+        useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
+        fileExists: (name) => {
+            const normalizedName = normalizeHostFileName(name);
+            return !!normalizedName && (files.has(normalizedName) || lpc.sys.fileExists(normalizedName));
+        },
+        readFile: (name) => {
+            const normalizedName = normalizeHostFileName(name);
+            return normalizedName ? files.get(normalizedName) ?? lpc.sys.readFile(normalizedName) : undefined;
+        },
+        onAllFilesNeedReparse: () => undefined,
+        onReleaseOldSourceFile: () => undefined,
+        onReleaseParsedCommandLine: () => undefined,
+    };
+
+    const fileHandler = lpc.createLpcFileHandler({
+        fileExists: (name) => host.fileExists(name),
+        readFile: (name) => host.readFile(name),
+        getIncludeDirs: () => host.getIncludeDirs(),
+        getCompilerOptions: () => host.getCompilationSettings(),
+        getCurrentDirectory: () => host.getCurrentDirectory(),
+    });
+
+    const ls = lpc.createLanguageService(host, fileHandler);
+
+    // force check every file so LPC inherits are resolved
+    const program = ls.getProgram()!;
+    for (const f of scriptFiles) {
+        program.getTypeChecker().getDiagnostics(program.getSourceFile(f));
+    }
+
+    return ls;
+}
+
+function renameCountsByFile(ls: lpc.LanguageService, fileName: string, pos: number) {
+    const locations = ls.findRenameLocations(fileName, pos, false, false) ?? [];
+    const byFile = new Map<string, number>();
+    for (const loc of locations) {
+        byFile.set(loc.fileName, (byFile.get(loc.fileName) ?? 0) + 1);
+    }
+    return byFile;
+}
+
+describe("LanguageService rename global var scope", () => {
+    it("does not rename same-named globals in unrelated files", () => {
+        const fileA = lpc.normalizePath(path.join(process.cwd(), "a.c"));
+        const fileB = lpc.normalizePath(path.join(process.cwd(), "b.c"));
+        const sourceA = `int foo;
+
+test() {
+    foo = 1;
+    return foo;
+}
+`;
+        const sourceB = `int foo;
+
+other() {
+    foo = 2;
+    return foo;
+}
+`;
+        const ls = makeLanguageService(new Map([[fileA, sourceA], [fileB, sourceB]]));
+
+        const declPos = sourceA.indexOf("foo");
+        const byFile = renameCountsByFile(ls, fileA, declPos);
+
+        expect(byFile.get(fileB) ?? 0).toBe(0);
+        expect(byFile.get(fileA)).toBe(3); // decl + 2 uses
+    });
+
+    it("renames inherited global var references in child files", () => {
+        const parent = lpc.normalizePath(path.join(process.cwd(), "parent.c"));
+        const child = lpc.normalizePath(path.join(process.cwd(), "child.c"));
+        const sourceParent = `int foo;
+
+test() {
+    foo = 1;
+    return foo;
+}
+`;
+        const sourceChild = `inherit "parent";
+
+child_fn() {
+    foo = 2;
+    return foo;
+}
+`;
+        const ls = makeLanguageService(new Map([[parent, sourceParent], [child, sourceChild]]));
+
+        const declPos = sourceParent.indexOf("foo");
+        const byFile = renameCountsByFile(ls, parent, declPos);
+
+        expect(byFile.get(parent)).toBe(3); // decl + 2 uses in parent
+        expect(byFile.get(child)).toBe(2); // 2 uses in child
+    });
+});


### PR DESCRIPTION
## Problem

Renaming (F2) a **file-scope global variable** renames every same-named global across the **entire mudlib**. A `foo` declared in one object file and an unrelated `foo` in a completely different file get rewritten together, even though they are distinct variables.

## Root cause

Rename delegates to `findAllReferences`, which fans out over *all* source files. Two things combine to leak matches:

1. **`getSymbolScope`** (`findAllReferences.ts`) treats a file-scope variable as *truly global* — it returns `undefined`, meaning "a reference can occur anywhere," so the search visits every file. This is inherited from the TypeScript architecture, where a script-mode global genuinely is global. On its own this only *widens the search*; matches are still meant to be confirmed by symbol identity.

2. **`getReferencesAtLocation`** had a fallback that defeated that confirmation. When the normal symbol-identity match (`getRelatedSymbol` → `search.includes`) failed, it added the reference **anyway**, keyed only on the identifier *name*:

   ```js
   } else {
       // I had to add this in to get object-level variables to show up
       // as references
       relatedSymbol = { symbol: referenceSymbol, kind: EntryKind.Node };
   }
   ```

**Why that fallback existed:** LPC's checker mints *distinct `Symbol` objects for the same file-global variable*. Even a reference and its own declaration within the same file are different `Symbol` objects (they share the same declaration *node*, but `search.includes(...)` compares identity, so it returns false). Without the fallback, legitimate same-file references to object-level variables didn't show up at all. Matching by name fixed that symptom — but then leaked to every same-named global in unrelated files, producing the mudlib-wide rename.

## Fix

Replace the name-based fallback with a **shared-declaration** check. A reference counts only when its symbol shares a declaration node with a symbol in the search set:

- **Same-file references** → share the declaration node → still found ✅
- **Inherited references** (a child file using an inherited global) → resolve to the inherited declaration → still found ✅
- **Same-named globals in unrelated files** → have their own separate declarations → **now excluded** ✅

`getSymbolScope` is intentionally left returning `undefined` for file-globals: searching all files is still required to catch *inherited* references in child objects. The new declaration filter is what makes that fan-out correct instead of over-broad.

This also corrects **Find All References**, which travels the same code path.

## Note for reviewers: possible follow-up (out of scope here)

This PR fixes **correctness** but not the **fan-out cost**. Because `getSymbolScope` still returns `undefined` for file-globals, every file-global rename/find-references walks *every* file in the program and text-scans each for the identifier; the new declaration filter then discards the non-matches. On a large mudlib that's more work than necessary.

A future optimization could narrow the scope to just the declaring file plus its known inheritors (rather than the whole program), which would cut the fan-out substantially. I left that out deliberately — it's a larger change, depends on how reliably the inheritance graph can be enumerated up-front, and isn't needed for correctness. Flagging it in case you'd prefer it done here or tracked separately.

## Tests

Adds `server/src/tests/renameGlobalVarScope.spec.ts`:

- **Unrelated-file isolation** — renaming `foo` in `a.c` touches only `a.c` (3 locations), not the unrelated `foo` in `b.c`. Before this change: 3 locations in `a.c` **and** 3 in `b.c`.
- **Inheritance** — renaming a global in a parent object also updates references in a child that `inherit`s it.

Full suite: **840/840 pass**, `tsc -b` clean.
