### PR TITLE
Fix: render internal tuple types instead of failing (`<never>` / "expected a type node" warning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix: Parse FluffOS anonymous function expressions `(function(params){...})`
 - Fix: report assignment to an undeclared variable under FluffOS
 - Fix: quick-info/hover for variables interpolated in template literals
+- Fix: render LPC spread-argument tuples as an array of element unions
 - Consolidate driver-specific keyword handling into the scanner
 
 ## 1.1.46

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fix: Parse FluffOS anonymous function expressions `(function(params){...})`
 - Fix: report assignment to an undeclared variable under FluffOS
 - Fix: quick-info/hover for variables interpolated in template literals
-- Fix: render LPC spread-argument tuples as an array of element unions
+- Fix: render internal tuple types instead of failing (`<never>` / "expected a type node" warning)
 - Consolidate driver-specific keyword handling into the scanner
 
 ## 1.1.46

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -20593,42 +20593,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return arrayType;
                 }
                 else if (type.target.objectFlags & ObjectFlags.Tuple) {
+                    // LPC has no tuple type syntax; tuples arise only internally (e.g. when
+                    // modeling spread/rest call arguments for a `varargs` function). Render
+                    // them as an array of the union of their element types so error messages
+                    // and hovers produce an LPC-valid type instead of failing to build a node.
                     typeArguments = sameMap(typeArguments, (t, i) => removeMissingType(t, !!((type.target as TupleType).elementFlags[i] & ElementFlags.Optional)));
-                    console.debug("todo - tuple type");
-                    // if (typeArguments.length > 0) {
-                    //     const arity = getTypeReferenceArity(type);
-                    //     const tupleConstituentNodes = mapToTypeNodes(typeArguments.slice(0, arity), context);
-                    //     if (tupleConstituentNodes) {
-                    //         const { labeledElementDeclarations } = type.target as TupleType;
-                    //         for (let i = 0; i < tupleConstituentNodes.length; i++) {
-                    //             const flags = (type.target as TupleType).elementFlags[i];
-                    //             const labeledElementDeclaration = labeledElementDeclarations?.[i];
-
-                    //             if (labeledElementDeclaration) {
-                    //                 tupleConstituentNodes[i] = factory.createNamedTupleMember(
-                    //                     flags & ElementFlags.Variable ? factory.createToken(SyntaxKind.DotDotDotToken) : undefined,
-                    //                     factory.createIdentifier(unescapeLeadingUnderscores(getTupleElementLabel(labeledElementDeclaration))),
-                    //                     flags & ElementFlags.Optional ? factory.createToken(SyntaxKind.QuestionToken) : undefined,
-                    //                     flags & ElementFlags.Rest ? factory.createArrayTypeNode(tupleConstituentNodes[i]) :
-                    //                         tupleConstituentNodes[i],
-                    //                 );
-                    //             }
-                    //             else {
-                    //                 tupleConstituentNodes[i] = flags & ElementFlags.Variable ? factory.createRestTypeNode(flags & ElementFlags.Rest ? factory.createArrayTypeNode(tupleConstituentNodes[i]) : tupleConstituentNodes[i]) :
-                    //                     flags & ElementFlags.Optional ? factory.createOptionalTypeNode(tupleConstituentNodes[i]) :
-                    //                     tupleConstituentNodes[i];
-                    //             }
-                    //         }
-                    //         const tupleTypeNode = setEmitFlags(factory.createTupleTypeNode(tupleConstituentNodes), EmitFlags.SingleLine);
-                    //         return (type.target as TupleType).readonly ? factory.createTypeOperatorNode(SyntaxKind.ReadonlyKeyword, tupleTypeNode) : tupleTypeNode;
-                    //     }
-                    // }
-                    // if (context.encounteredError || (context.flags & NodeBuilderFlags.AllowEmptyTuple)) {
-                    //     const tupleTypeNode = setEmitFlags(factory.createTupleTypeNode([]), EmitFlags.SingleLine);
-                    //     return (type.target as TupleType).readonly ? factory.createTypeOperatorNode(SyntaxKind.ReadonlyKeyword, tupleTypeNode) : tupleTypeNode;
-                    // }
-                    context.encounteredError = true;
-                    return undefined!; // TODO: GH#18217
+                    const elementUnion = typeArguments.length ? getUnionType(typeArguments as Type[]) : anyType;
+                    let elementTypeNode = typeToTypeNodeHelper(elementUnion, context);
+                    if (elementTypeNode.kind === SyntaxKind.UnionType || elementTypeNode.kind === SyntaxKind.IntersectionType) {
+                        elementTypeNode = factory.createParenthesizedType(elementTypeNode);
+                    }
+                    return factory.createArrayTypeNode(elementTypeNode);
                 }
                 else if (
                     context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral &&
@@ -32577,7 +32552,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const typeNode = nodeBuilder.typeToTypeNode(type, enclosingDeclaration, toNodeBuilderFlags(flags) | NodeBuilderFlags.IgnoreErrors | (noTruncation ? NodeBuilderFlags.NoTruncation : 0));
         if (typeNode === undefined) {
             console.warn("expected a type node but didn't get one");
-            const typeNode2 = nodeBuilder.typeToTypeNode(type, enclosingDeclaration, toNodeBuilderFlags(flags) | NodeBuilderFlags.IgnoreErrors | (noTruncation ? NodeBuilderFlags.NoTruncation : 0));
             return "<never>";
         }
         // The unresolved type gets a synthesized comment on `any` to hint to users that it's not a plain `any`.

--- a/server/src/tests/tupleTypeRendering.spec.ts
+++ b/server/src/tests/tupleTypeRendering.spec.ts
@@ -1,0 +1,41 @@
+import * as lpc from "./_namespaces/lpc.js";
+import * as path from "path";
+
+/**
+ * LPC has no tuple type syntax, but the checker builds tuple types internally when
+ * modeling spread/rest call arguments. Calling an overloaded efun such as `min` with
+ * several positional arguments produces a spread tuple (e.g. `[int, string]`) that is
+ * checked against the efun's overloads. Rendering that tuple for a diagnostic used to
+ * fail in the type-node builder -- the tuple case set `encounteredError` and returned
+ * undefined, so the type printed as `<never>` (and `typeToString` logged a warning).
+ *
+ * The builder now renders a tuple as an array of its element-type union, so the type is
+ * shown correctly in the message.
+ */
+function diagnosticMessages(source: string, driverType = lpc.LanguageVariant.LDMud): string[] {
+    const cwd = lpc.normalizePath(process.cwd());
+    const fileName = lpc.normalizePath(path.join(cwd, "tuple.c"));
+    const options: lpc.CompilerOptions = { driverType, diagnostics: true };
+    const host = lpc.createCompilerHost(options);
+    host.getDefaultLibFileName = () =>
+        lpc.combinePaths(cwd, lpc.getDefaultLibFolder(options), lpc.getDefaultLibFileName(options));
+    const origRead = host.readFile.bind(host);
+    host.readFile = (n?: string) => (n && lpc.normalizePath(n) === fileName ? source : (n ? origRead(n) : undefined));
+    host.fileExists = (n?: string) => (n ? (lpc.normalizePath(n) === fileName ? true : lpc.sys.fileExists(n)) : false);
+    const program = lpc.createProgram({ host, rootNames: [fileName], options, oldProgram: undefined });
+    const file = program.getSourceFile(fileName)!;
+    return [...file.parseDiagnostics, ...program.getSemanticDiagnostics(file)].map(d =>
+        lpc.flattenDiagnosticMessageText(d.messageText, "\n"));
+}
+
+describe("tuple type rendering in the node builder", () => {
+    it("renders a spread-argument tuple as an array of its element union, not `<never>`", () => {
+        // `min(1, "a")` has no matching overload; the [int, string] spread tuple appears in
+        // the mismatch message. Before the fix it rendered as `<never>`.
+        const messages = diagnosticMessages(`void f() { mixed x = min(1, "a"); }\n`);
+        const argError = messages.find(m => /Argument of type .* is not assignable/.test(m));
+        expect(argError).toBeDefined();
+        expect(argError).toContain("(string | int)*");
+        expect(argError).not.toContain("<never>");
+    });
+});


### PR DESCRIPTION
### Symptom

The language server intermittently logged `expected a type node but didn't get one` (checker.ts `typeToString`). It was hard to track down because it surfaced from *discarded* error-elaboration passes — the final diagnostics were usually fine, so nothing user-visible pointed at the cause. A real-world trigger was `min(100, roundToInt(...))` in a lib file.

### Root cause

LPC has no tuple type syntax, but the checker builds tuple types **internally** when modeling spread/rest call arguments. Calling an overloaded efun like `min`/`max` with several positional args produces a spread tuple (e.g. `[int, string]`) that gets checked against each overload's rest parameter. The mismatching overloads elaborate error messages that call `typeToString` on the tuple.

The type-node builder's tuple case was never implemented — it did `context.encounteredError = true; return undefined`. `withContext` turns `encounteredError` into `undefined`, so `typeToString` got nothing back and:
- logged the warning, and
- rendered the type as `<never>` in any message that *did* survive.

### Fix

Implement the tuple case in `typeReferenceToTypeNode`: render a tuple as an **array of the union of its element types** (parenthesizing a union element), which is the natural LPC representation.

- `[int, int]` → `int*`
- `[int, string]` → `(string | int)*`

Also removed a stray dead `typeNode2` recomputation at the warn site.

### Impact

No behavior change for valid code (these tuples only arise in overload elaboration that gets discarded once a matching overload is found). Where a tuple *does* reach a surfaced diagnostic or hover, it now shows a readable `T*` instead of `<never>`.

### Test

`tupleTypeRendering.spec.ts` — `min(1, "a")` has no matching overload, so the `[int, string]` spread tuple appears in a real diagnostic. Asserts the message contains `(string | int)*` and not `<never>`. Verified it fails on the pre-fix code (renders `<never>`).
