### PR TITLE
Memory-bounded full check for large mudlibs — `forEachProgramBatch` (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LPC Language Services Changelog
 
+## 1.1.48
+
+- Memory-bounded full check for large mudlibs — forEachProgramBatch ([#282](https://github.com/jlchmura/lpc-language-server/issues/282))
+
 ## 1.1.47
 
 - Feature: Add Workspace Symbols (Cmd+T / workspace/symbol) with fuzzy matching

--- a/server/src/compiler/_namespaces/lpc.ts
+++ b/server/src/compiler/_namespaces/lpc.ts
@@ -34,6 +34,7 @@ export * from "../watch.js";
 export * from "../watchUtilities.js";
 export * from "../sys.js";
 export * from "../program.js";
+export * from "../programBatch.js";
 export * from "../transformers.js";
 export * from "../transformers/declarations.js";
 export * from "../emitter.js";

--- a/server/src/compiler/executeCommandLine.ts
+++ b/server/src/compiler/executeCommandLine.ts
@@ -1,4 +1,4 @@
-import { BuildOptions, BuilderProgram, CompilerOptions, CreateProgramOptions, Debug, Diagnostic, DiagnosticReporter, DiagnosticWithLocation, Diagnostics, DriverTypeMap, ExitStatus, Extension, ForegroundColorEscapeSequences, ParsedCommandLine, Program, SourceFile, System, WatchOptions, combinePaths, createCompilerHost, createDiagnosticReporter, createGetCanonicalFileName, createProgram, fileExtensionIs, fileExtensionIsOneOf, findArgument, findConfigFile, forEach, formatColorAndReset, getBaseFileName, getDefaultLibFileName, getDefaultLibFolder, getDiagnosticText, getDirectoryPath, getErrorSummaryText, getFilesInErrorForSummary, getLineStarts, isDiskPathRoot, noop, normalizePath, parseJsonText, parseLpcSourceFileConfigFileContent, performance, reduceLeftIterator, sortAndDeduplicateDiagnostics, startsWith, supportedTSExtensionsFlat, sys, version } from "./_namespaces/lpc";
+import { BuildOptions, BuilderProgram, CompilerHost, CompilerOptions, CreateProgramOptions, Debug, Diagnostic, DiagnosticReporter, DiagnosticWithLocation, Diagnostics, DriverTypeMap, ExitStatus, Extension, ForegroundColorEscapeSequences, ParsedCommandLine, Program, SourceFile, System, WatchOptions, combinePaths, createCompilerHost, createDiagnosticReporter, createGetCanonicalFileName, createProgram, fileExtensionIs, fileExtensionIsOneOf, findArgument, findConfigFile, forEach, forEachProgramBatch, formatColorAndReset, getBaseFileName, getDefaultLibFileName, getDefaultLibFolder, getDiagnosticText, getDirectoryPath, getErrorSummaryText, getFilesInErrorForSummary, getLineStarts, isDiskPathRoot, noop, normalizePath, parseJsonText, parseLpcSourceFileConfigFileContent, performance, reduceLeftIterator, sortAndDeduplicateDiagnostics, startsWith, supportedTSExtensionsFlat, sys, version } from "./_namespaces/lpc";
 
 
 export enum ExecuteCommandMsgType {
@@ -57,12 +57,16 @@ export function executeCommandLine(
     system.write(`Found ${parsedConfig.fileNames.length} files.\n`);
     system.write(`Efun Definitions: ${normalizePath(compilerHost.getDefaultLibFileName(compilerOptions))}\n`);
 
-    const createProgramOptions: CreateProgramOptions = {
-        host: compilerHost,
-        rootNames: parsedConfig.fileNames,
-        options: compilerOptions,                
-        oldProgram: undefined,                
+    // Each batch builds its own program from a fresh host so the host's file cache is released
+    // with the batch; mirror the default-lib override applied to `compilerHost` above.
+    const makeBatchHost = (o: CompilerOptions): CompilerHost => {
+        const h = createCompilerHost(o);
+        h.getDefaultLibFileName = () => combinePaths(execPath, "../", getDefaultLibFolder(o), getDefaultLibFileName(o));
+        return h;
     };
+
+    const batchSizeArg = findArgument("--batchSize", commandLineArgs);
+    const batchSize = batchSizeArg && /^\d+$/.test(batchSizeArg) ? parseInt(batchSizeArg, 10) : undefined;
 
     function defaultIsPretty(sys: System) {
         return !!sys.writeOutputIsTTY && sys.writeOutputIsTTY() && !sys.getEnvironmentVariable("NO_COLOR");
@@ -91,38 +95,53 @@ export function executeCommandLine(
         compilerOptions
     );
 
-    // create program and get file we are trying to compile
-    const program = createProgram(createProgramOptions);
+    // Check the project in memory-bounded batches: each batch gets its own program (a chunk of
+    // roots + their dependency closure) which is released before the next, so peak memory stays
+    // ~one batch instead of holding every file's AST + checker state at once (issue #282).
+    const rootFiles = parsedConfig.fileNames;
 
-    const diags: DiagnosticWithLocation[] = [];
-    const rootFiles = program.getRootFileNames();
+    // Reported per batch, so we never retain Diagnostic objects (whose `.file` pins a whole
+    // SourceFile) across batches. Only the lightweight per-file error summary and running
+    // count survive between batches.
+    const filesInErrorSummary: ReturnType<typeof getFilesInErrorForSummary> = [];
+    let reportedDiagnosticCount = 0;
+    let lastProgram: Program | undefined;
 
-    rootFiles.forEach(f => {
-        try {
-            const sourceFile = program.getSourceFile(f);    
-            const parseDiags = program.getSyntacticDiagnostics(sourceFile);
-            diags.push(...parseDiags);
-            
-            if (compilerOptions.diagnostics) {
-                const semanticDiags = program.getSemanticDiagnostics(sourceFile);
-                diags.push(...semanticDiags);
-            }        
-        } catch (e) {
-            system.write(`Error processing file: ${f}\n`);            
-            throw e;        
-        }
-    });
+    forEachProgramBatch(
+        { rootNames: rootFiles, options: compilerOptions, batchSize, createHost: makeBatchHost },
+        (program, batchRootNames) => {
+            const diags: DiagnosticWithLocation[] = [];
+            batchRootNames.forEach(f => {
+                try {
+                    const sourceFile = program.getSourceFile(f);
+                    diags.push(...program.getSyntacticDiagnostics(sourceFile));
+                    if (compilerOptions.diagnostics) {
+                        diags.push(...program.getSemanticDiagnostics(sourceFile));
+                    }
+                } catch (e) {
+                    system.write(`Error processing file: ${f}\n`);
+                    throw e;
+                }
+            });
 
-    sortAndDeduplicateDiagnostics(diags).forEach(d => {
-        reportDiagnostic(d);
-    });
+            if (diags.length) {
+                const sorted = sortAndDeduplicateDiagnostics(diags);
+                sorted.forEach(reportDiagnostic);
+                reportedDiagnosticCount += sorted.length;
+                filesInErrorSummary.push(...getFilesInErrorForSummary(sorted));
+            }
 
-    if (diags.length) {
+            // Only retained under --perf, where end-of-run statistics need a program to inspect.
+            if (performanceEnabled) lastProgram = program;
+        },
+    );
+
+    if (reportedDiagnosticCount) {
         system.write("\n");
-        if (msgCallback) {            
-            const diagTxt = getErrorSummaryText(diags.length, getFilesInErrorForSummary(diags), "\n", compilerHost);
+        if (msgCallback) {
+            const diagTxt = getErrorSummaryText(reportedDiagnosticCount, filesInErrorSummary, "\n", compilerHost);
             msgCallback(diagTxt, ExecuteCommandMsgType.Failure);
-        }        
+        }
     } else if (rootFiles.length) {
         const messages = [
             "Your code is so fresh and so clean, clean.",
@@ -141,8 +160,10 @@ export function executeCommandLine(
         }        
     }    
     
-    if (performanceEnabled) {
-        reportStatistics(sys, program, solutionPerformance);        
+    if (performanceEnabled && lastProgram) {
+        // In batched mode this reflects the final batch only (the whole project no longer lives
+        // in a single program); for a project small enough to fit in one batch it is exact.
+        reportStatistics(sys, lastProgram, solutionPerformance);
         reportSolutionBuilderTimes(solutionPerformance);
     }
 }

--- a/server/src/compiler/programBatch.ts
+++ b/server/src/compiler/programBatch.ts
@@ -1,0 +1,70 @@
+import {
+    CompilerHost,
+    CompilerOptions,
+    createCompilerHost,
+    createProgram,
+    Program,
+} from "./_namespaces/lpc";
+
+/** Default number of root files processed per batch by {@link forEachProgramBatch}. */
+export const defaultProgramBatchSize = 1000;
+
+export interface ProgramBatchOptions {
+    /** The full set of root files to process (e.g. an lpc-config's matched file list). */
+    rootNames: readonly string[];
+    /** Compiler options shared by every batch. */
+    options: CompilerOptions;
+    /**
+     * Maximum root files per batch. Each batch builds an independent {@link Program} from its
+     * root chunk plus the dependency closure those roots pull in on demand. Smaller batches
+     * lower peak memory but re-parse shared dependencies more often. Defaults to
+     * {@link defaultProgramBatchSize}; values below 1 are treated as 1.
+     */
+    batchSize?: number;
+    /**
+     * Factory for the {@link CompilerHost} each batch uses. A fresh host per batch ensures the
+     * host's own source-file cache is released along with the batch. Defaults to
+     * `createCompilerHost(options)`; override to customize e.g. `getDefaultLibFileName`.
+     */
+    createHost?: (options: CompilerOptions) => CompilerHost;
+}
+
+/**
+ * Processes a large set of root files in memory-bounded batches, invoking `cb` with a fully
+ * usable {@link Program} for each batch and then releasing it before building the next.
+ *
+ * Why: a single Program keeps every bound `SourceFile` and the type checker's caches alive for
+ * its whole lifetime, so checking a 40k-file mudlib in one Program exhausts the heap. Each
+ * batch here builds a Program from a chunk of roots (plus their lazily loaded dependency
+ * closure); once `cb` returns, all references to that Program and its host are dropped, so the
+ * GC can reclaim its ASTs and checker state. Peak memory stays ~one batch instead of growing
+ * to the whole project.
+ *
+ * Correctness: a file's semantic diagnostics depend only on the files it *depends on*
+ * (inherits / includes / simul_efun / efuns), which are pulled into the same batch as non-root
+ * sources — never on the files that depend on *it*. Every root is processed in exactly one
+ * batch, so nothing is missed or duplicated.
+ *
+ * Caveat for callers: to keep the batching effective, do NOT retain a batch's `Program`, its
+ * `SourceFile`s, `Node`s, `Symbol`s, `Type`s, or `Diagnostic`s (whose `.file` points at a
+ * `SourceFile`) after `cb` returns — extract the plain data you need (strings, positions)
+ * inside the callback. Holding any of these pins that batch's AST in memory across batches.
+ */
+export function forEachProgramBatch(
+    opts: ProgramBatchOptions,
+    cb: (program: Program, batchRootNames: readonly string[], batchIndex: number) => void,
+): void {
+    const { rootNames, options } = opts;
+    const batchSize = Math.max(1, opts.batchSize ?? defaultProgramBatchSize);
+    const createHost = opts.createHost ?? ((o: CompilerOptions) => createCompilerHost(o));
+
+    let batchIndex = 0;
+    for (let start = 0; start < rootNames.length; start += batchSize) {
+        const batchRootNames = rootNames.slice(start, start + batchSize);
+        const host = createHost(options);
+        const program = createProgram({ host, rootNames: batchRootNames, options, oldProgram: undefined });
+        cb(program, batchRootNames, batchIndex++);
+        // `host` and `program` fall out of scope here; nothing global retains their files on
+        // this path (no DocumentRegistry), so they become eligible for GC before the next batch.
+    }
+}

--- a/server/src/tests/programBatch.spec.ts
+++ b/server/src/tests/programBatch.spec.ts
@@ -1,0 +1,94 @@
+import * as lpc from "./_namespaces/lpc.js";
+import * as path from "path";
+
+/**
+ * `forEachProgramBatch` checks a large root set in memory-bounded batches, building an
+ * independent program per chunk (root chunk + its lazily loaded dependency closure) and
+ * releasing it before the next. These tests assert the behavior that makes it a safe
+ * replacement for a single whole-project program (issue #282):
+ *   - a file's dependencies (e.g. an inherited parent) are resolved within its own batch, and
+ *   - the union of per-batch diagnostics equals a single full program's diagnostics.
+ */
+const options: lpc.CompilerOptions = { driverType: lpc.LanguageVariant.FluffOS, diagnostics: true };
+
+function makeHost(files: Map<string, string>): lpc.CompilerHost {
+    const cwd = lpc.normalizePath(process.cwd());
+    const host = lpc.createCompilerHost(options);
+    host.getDefaultLibFileName = () =>
+        lpc.combinePaths(cwd, lpc.getDefaultLibFolder(options), lpc.getDefaultLibFileName(options));
+    const norm = (n?: string) => (n ? lpc.normalizePath(n) : n);
+    const origRead = host.readFile.bind(host);
+    host.readFile = (n?: string) => {
+        const k = norm(n);
+        return k && files.has(k) ? files.get(k)! : (n ? origRead(n) : undefined);
+    };
+    host.fileExists = (n?: string) => {
+        const k = norm(n);
+        return !!k && (files.has(k) || lpc.sys.fileExists(n!));
+    };
+    return host;
+}
+
+function checkFile(program: lpc.Program, fileName: string): string[] {
+    const sf = program.getSourceFile(fileName);
+    return [...program.getSyntacticDiagnostics(sf), ...program.getSemanticDiagnostics(sf)]
+        .map(d => `${lpc.normalizePath(d.file?.fileName ?? "")}: ${lpc.flattenDiagnosticMessageText(d.messageText, "\n")}`);
+}
+
+function singleProgramDiagnostics(files: Map<string, string>, roots: string[]): string[] {
+    const program = lpc.createProgram({ host: makeHost(files), rootNames: roots, options, oldProgram: undefined });
+    return roots.flatMap(r => checkFile(program, r)).sort();
+}
+
+function batchedDiagnostics(files: Map<string, string>, roots: string[], batchSize: number): { diags: string[]; batches: number } {
+    const diags: string[] = [];
+    let batches = 0;
+    lpc.forEachProgramBatch(
+        { rootNames: roots, options, batchSize, createHost: () => makeHost(files) },
+        (program, batchRootNames) => {
+            batches++;
+            for (const f of batchRootNames) diags.push(...checkFile(program, f));
+        },
+    );
+    return { diags: diags.sort(), batches };
+}
+
+describe("forEachProgramBatch", () => {
+    const P = (n: string) => lpc.normalizePath(path.join(process.cwd(), n));
+    const files = new Map<string, string>([
+        [P("parent.c"), "int shared_global;\n"],
+        [P("child.c"), 'inherit "parent";\nvoid use() { shared_global = 1; }\n'],
+        [P("bad.c"), "void f() { undeclared_thing = 1; }\n"],
+        [P("badret.c"), 'int f() { return "s"; }\n'],
+    ]);
+    const roots = [P("parent.c"), P("child.c"), P("bad.c"), P("badret.c")];
+
+    it("splits roots into the expected number of batches", () => {
+        expect(batchedDiagnostics(files, roots, 1).batches).toBe(4);
+        expect(batchedDiagnostics(files, roots, 2).batches).toBe(2);
+        expect(batchedDiagnostics(files, roots, 100).batches).toBe(1);
+        expect(batchedDiagnostics(files, roots, 3).batches).toBe(2); // 3 + 1
+    });
+
+    it("produces the same diagnostics as a single whole-project program", () => {
+        const baseline = singleProgramDiagnostics(files, roots);
+        // Sanity: the baseline actually contains the seeded errors and nothing spurious.
+        expect(baseline).toEqual([
+            `${P("bad.c")}: Cannot find name 'undeclared_thing'.`,
+            `${P("badret.c")}: Type 'string' is not assignable to type 'int'.`,
+        ]);
+        // Maximal batching (one file per program) must match exactly...
+        expect(batchedDiagnostics(files, roots, 1).diags).toEqual(baseline);
+        // ...as must a couple of other batch sizes.
+        expect(batchedDiagnostics(files, roots, 2).diags).toEqual(baseline);
+        expect(batchedDiagnostics(files, roots, 100).diags).toEqual(baseline);
+    });
+
+    it("resolves a file's dependencies inside its own batch (inherited global stays clean)", () => {
+        // With one file per batch, child.c is checked alone; its `inherit \"parent\"` must pull
+        // parent.c into the batch so `shared_global` resolves -- otherwise we'd see a
+        // \"Cannot find name 'shared_global'\" diagnostic here.
+        const { diags } = batchedDiagnostics(files, [P("child.c")], 1);
+        expect(diags).toEqual([]);
+    });
+});


### PR DESCRIPTION
### Problem

The language server lazy-loads files, so the LSP stays within memory even on 40k-file mudlibs. But every **non-LSP** entry point — the CLI, and any library consumer (e.g. BeDoc's LPC parser) that calls `lpc.createProgram(allFiles)` — builds a **single** program with every config-matched file as a root. One program keeps every bound `SourceFile` plus the type checker's caches alive for its entire lifetime, so a full check of a large lib climbs past 3 GB and gets OOM-killed:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

You can't make a single whole-project program cheap, but a full check doesn't *need* one program — it needs every file checked once.

### What this adds

`forEachProgramBatch(opts, cb)` — processes a large root-file set in memory-bounded batches. Each batch builds an independent `Program` from a chunk of roots (plus the dependency closure those roots pull in on demand), hands it to your callback, then **drops it before building the next** so the GC reclaims that batch's ASTs and checker state. Peak memory stays ~one batch instead of growing to the whole project.

- New primitive exported from the public lib (`server/src/compiler/programBatch.ts`).
- `executeCommandLine` now uses it, with a `--batchSize N` flag (default `1000`).

### How a consumer like BeDoc should use it

BeDoc drives the compiler API directly to walk each file's AST/types and emit docs. Instead of one `createProgram` over the whole lib, iterate batches and do your per-file work inside the callback:

```js
import * as lpc from "@jlchmura/lpc-language-server";

lpc.forEachProgramBatch(
  {
    rootNames: allLpcFiles,          // the full file list (e.g. from the lpc-config)
    options,                         // your CompilerOptions (driverType, diagnostics, …)
    batchSize: 500,                  // optional; defaults to 1000
    // Optional: customize the per-batch host, e.g. to point at your efun defs.
    // A fresh host per batch is created for you by default.
    createHost: (o) => {
      const host = lpc.createCompilerHost(o);
      host.getDefaultLibFileName = () => efunDefsPath;
      return host;
    },
  },
  (program, batchFiles /*, batchIndex */) => {
    for (const file of batchFiles) {
      const sourceFile = program.getSourceFile(file);
      const checker = program.getTypeChecker();

      // Walk sourceFile, query types via checker, read diagnostics —
      // and emit your documentation as PLAIN data right here.
      emitDocsFor(file, extractDocModel(sourceFile, checker));
    }
    // `program` is released after this callback returns.
  },
);
```

`program` is a normal, fully usable `Program`: `getSourceFile`, `getTypeChecker`, `getSyntacticDiagnostics`, `getSemanticDiagnostics`, etc. all work exactly as before — you just get one batch's worth at a time.

### The one rule you must follow

**Do not retain a batch's `Program`, `SourceFile`, `Node`, `Symbol`, `Type`, or `Diagnostic` after the callback returns.** A `Diagnostic.file` (and every `Node`/`Symbol`/`Type`) points back into the `SourceFile`, so stashing any of them in an outer array pins that batch's entire AST in memory and defeats the batching. Extract the plain data you need — strings, numbers, positions, your own doc objects — **inside** the callback, and let the program go.

The CLI demonstrates the pattern: it reports diagnostics per batch and carries only a lightweight `{ fileName, line }` summary between batches, never the `Diagnostic` objects themselves.

### Why it's correct (nothing missed or duplicated)

A file's diagnostics depend only on what it **depends on** — the files it inherits/includes, simul_efun, the efun lib — all of which are pulled into the same batch as non-root sources when that file is checked. They never depend on the files that depend on *it* (its inheritors), which are checked in their own batches. Every root is processed in exactly one batch, so results are identical to a single whole-project program.

### Cost / tuning

Hot shared dependencies (simul_efun, common base classes, the efun lib) get re-parsed once per batch that references them, so total CPU rises in exchange for bounded memory. `batchSize` is the dial: **larger** = less dependency re-parsing, higher peak memory; **smaller** = the reverse. If dependency re-parsing later dominates, an LRU cache of *parsed* hot-dep `SourceFile`s shared across batch hosts is a clean follow-up that keeps the main win (discarding each batch's checker state).

Immediate band-aid for anyone stuck today, without upgrading: `NODE_OPTIONS=--max-old-space-size=8192`.

### Tests

`server/src/tests/programBatch.spec.ts`:
- batched output **equals** a single whole-project program's diagnostics at batch sizes 1, 2, and 100;
- correct batch counts for various sizes;
- a file's `inherit` resolves inside its own single-file batch (inherited global stays clean — proving the dependency closure loads per batch).

Plus an end-to-end check that the batched `executeCommandLine` path surfaces semantic errors and the failure summary. 