### PR TITLE
Fix: allow whitespace between @param & ref modifier and the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.48
 
 - Memory-bounded full check for large mudlibs — forEachProgramBatch ([#282](https://github.com/jlchmura/lpc-language-server/issues/282))
+- Fix: LPCDoc `@param` accepts whitespace between the `&` ref modifier and the parameter name (`{int} & value`), matching the FluffOS `int & value` signature spelling
 
 ## 1.1.47
 

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -6456,6 +6456,10 @@ export namespace LpcParser {
                 const isBackquoted = parseOptionalJsdoc(SyntaxKind.BacktickToken);
                 // allow &name for pass-by-reference params (LPC ref keyword)
                 const isRef = !!parseOptionalJsdoc(SyntaxKind.AmpersandToken);
+                if (isRef) {
+                    // permit whitespace between '&' and the name, mirroring FluffOS `int & value`
+                    skipWhitespace();
+                }
                 const name = parseJSDocEntityName();
                 let expr: Expression = undefined;
 

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -473,6 +473,8 @@ Found 2 errors in the same file, starting at: server/src/tests/cases/compiler/js
 "
 `;
 
+exports[`Compiler compiler/jsDocParamRefWhitespace.c Reports correct errors for compiler/jsDocParamRefWhitespace.c: diags-compiler/jsDocParamRefWhitespace.c 1`] = `""`;
+
 exports[`Compiler compiler/jsDocParamTypeMismatch.c Reports correct errors for compiler/jsDocParamTypeMismatch.c: diags-compiler/jsDocParamTypeMismatch.c 1`] = `
 "
 Found 2 errors in the same file, starting at: server/src/tests/cases/compiler/jsDocParamTypeMismatch.c[90m:3[0m

--- a/server/src/tests/cases/compiler/jsDocParamRefWhitespace.c
+++ b/server/src/tests/cases/compiler/jsDocParamRefWhitespace.c
@@ -1,0 +1,21 @@
+// A space between '&' and the parameter name binds the same as the glued form,
+// mirroring the FluffOS signature spelling `int & value`. Both should validate
+// against a pass-by-reference parameter without error.
+
+/**
+ * @param {int} & value - spaced reference parameter
+ */
+void increment(int ref value) {
+    value++;
+}
+
+/**
+ * @param {mixed*} & arr - spaced reference array parameter
+ * @param {mixed} value - a regular parameter
+ */
+void push_val(mixed ref *arr, mixed value) {
+    arr += ({ value });
+}
+
+// @errors: 0
+// @driver: fluffos


### PR DESCRIPTION
## Summary

LPCDoc `@param` accepts the `&` pass-by-reference marker glued to the name (`@param {int} &value`), but not with a space (`@param {int} & value`). The spaced form matches how the modifier is spelled in a FluffOS signature — `int & value` — so writing docs currently forces a shape mismatch between the annotation and the code it documents.

The parser consumed the `&` and then read the name **immediately**, so with a space it parsed an empty name and emitted `'@param' tag has name '', but there is no parameter with that name` instead of binding to the parameter. This adds a single `skipWhitespace()` after the `&`.

## Behavior

| Annotation (code has `int ref value`) | Before | After |
|---|---|---|
| `@param {int} &value` (glued) | ✅ | ✅ |
| `@param {int} & value` (spaced) | ❌ empty name | ✅ binds |
| `@param {int} & value` + non-ref param | ✅ errors (mismatch) | ✅ errors (mismatch) |
| `@type {"a.c" & "b.c"}` (intersection) | ✅ | ✅ unchanged |

The `&` sits outside the `{type}` braces, so intersection types are unaffected, and the existing ref/annotation mismatch validation is preserved.

## Tests

Adds `jsDocParamRefWhitespace.c` covering the spaced form on both a scalar and an array reference parameter. Full compiler suite passes (792 tests, no snapshot regressions).