### PR TITLE
Fix: highlight @param {type} &name ref modifier and parameter name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Memory-bounded full check for large mudlibs — forEachProgramBatch ([#282](https://github.com/jlchmura/lpc-language-server/issues/282))
 - Fix: LPCDoc `@param` accepts whitespace between the `&` ref modifier and the parameter name (`{int} & value`), matching the FluffOS `int & value` signature spelling
+- Fix: syntax highlighting for LPCDoc `@param {type} &name` — the `&` ref modifier and the parameter name were rendered as plain comment text; the `&` now highlights as a modifier and the name as a variable (both the `&name` and `& name` spellings)
 
 ## 1.1.47
 

--- a/syntaxes/lpc.tmLanguage.json
+++ b/syntaxes/lpc.tmLanguage.json
@@ -985,10 +985,18 @@
 							"name": "punctuation.definition.block.tag.jsdoc"
 						}
 					},
-					"end": "(?=\\s|\\*/|[^{}\\[\\]A-Za-z_$])",
+					"end": "(?=\\s|\\*/|[^{}\\[\\]A-Za-z_$&])",
 					"patterns": [
 						{
 							"include": "#jsdoctype"
+						},
+						{
+							"match": "(&)\\s*",
+							"captures": {
+								"1": {
+									"name": "storage.modifier.reference.jsdoc"
+								}
+							}
 						},
 						{
 							"name": "variable.other.jsdoc",


### PR DESCRIPTION
## Problem

Follow-up to #340. That PR fixed the **parser** for the `&` pass-by-reference marker in LPCDoc `@param`, but the **syntax highlighting** is still wrong: in `@param {type} &name`, both the `&` and the parameter name render as plain comment text instead of a keyword/modifier and a variable.

## Cause

In the typed `@param` grammar rule (`syntaxes/lpc.tmLanguage.json`), after the `{type}` block is consumed the region's `end` pattern is:

```
(?=\s|\*/|[^{}\[\]A-Za-z_$])
```

`&` matches the negated class `[^…A-Za-z_$]`, so the region **terminates at the `&`** before its inner variable-name pattern can run. Everything from `&` onward (marker, name, description) falls through to the base `comment.block.documentation.lpc` scope. A normal name starts with a letter (excluded from the class), so the region stays open and the name highlights — which is why only the ref form breaks.

## Fix

- Add `&` to the `end` exclusion class so the region no longer terminates at the marker.
- Add an inner pattern `(&)\s*` scoped `storage.modifier.reference.jsdoc`; the existing `variable.other.jsdoc` pattern then picks up the name.

Both the glued `&name` and spaced `& name` spellings now highlight identically to a plain `@param {type} name`. Descriptions, optional `[name]` forms, and a `&` appearing inside a description are unaffected.

## Verification

Grammar-only change to a static tmLanguage asset (no runtime/parser code, so no unit-test surface — the repo has no tokenization harness). Verified with `vscode-textmate` against both spellings taken from a real mudlib file:

| input | `&` scope | name scope |
|---|---|---|
| `@param {mixed*} & arr` | `storage.modifier.reference.jsdoc` | `variable.other.jsdoc` |
| `@param {mixed*} &arr`  | `storage.modifier.reference.jsdoc` | `variable.other.jsdoc` |
| `@param {mixed*} arr` (control) | — | `variable.other.jsdoc` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)