### PR TITLE
Fix crash when hovering `new` on the string-path clone form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: foreach loop variable type checking [#344](https://github.com/jlchmura/lpc-language-server/pull/344)
 - Fix: allow the `time_expression` efun to be declared in efun definition headers so it keeps completion and lpcdoc support
 - Fix: hovering the `time_expression` keyword now shows the efun signature and lpcdoc
+- Fix: hovering the `new` keyword on the string-path clone form (`new("/path")`) no longer crashes the quick-info request
 
 ## 1.1.48
 

--- a/server/src/services/services.ts
+++ b/server/src/services/services.ts
@@ -1989,7 +1989,10 @@ export function createLanguageService(
     }
 
     function getNodeForQuickInfo(node: Node): Node {
-        if (node.parent && isNewExpression(node.parent) && node.pos === node.parent.pos) {
+        // For `new Foo()` hovering `new` shows info about `Foo`. But the FluffOS string-path
+        // clone form `new("/path")` has no expression (the path is an argument), so guard
+        // against returning undefined -- fall through to the `new` keyword token instead.
+        if (node.parent && isNewExpression(node.parent) && node.parent.expression && node.pos === node.parent.pos) {
             return node.parent.expression;
         }
         // if (isNamedTupleMember(node.parent) && node.pos === node.parent.pos) {

--- a/server/src/tests/quickinfo.spec.ts
+++ b/server/src/tests/quickinfo.spec.ts
@@ -212,6 +212,18 @@ void test(int i) {
         }
     });
 
+    it("does not throw when hovering `new` on the string-path clone form", () => {
+        // `new("/path")` has no expression (the path is an argument), so getNodeForQuickInfo
+        // must not hand an undefined node down the hover pipeline.
+        const source = `void f() {
+    object coins = new("/std/item/coins.c");
+}
+`;
+        const { ls, fileName } = createLanguageService(source);
+        const pos = source.indexOf("new(") + 1;
+        expect(() => ls.getQuickInfoAtPosition(fileName, pos)).not.toThrow();
+    });
+
     it("respects an explicit value-variable annotation in a mapping foreach", () => {
         // https://github.com/jlchmura/lpc-language-server/issues/318
         // The mapping's inferred value type is a mapping, but the user explicitly


### PR DESCRIPTION
### Summary

Hovering the `new` keyword in the FluffOS string-path clone form — `new("/std/item/coins.c")` — crashed the quick-info request with `TypeError: Cannot read properties of undefined (reading 'flags')`.

### Repro

```lpc
mixed do_drop_wrd_wrd (mixed args...) {
    object coins;
    coins = new("/std/item/coins.c");   // hover on `new` here
    ...
}
```

Hovering `new` produced:

```
Cannot read properties of undefined (reading 'flags')
    at getSymbolAtLocationForQuickInfo (services.ts:2295)
    at Object.getQuickInfoAtPosition (services.ts:2060)
    ...
```

### Root cause

`getNodeForQuickInfo` has a special case so that hovering `new` in `new Foo()` redirects to `Foo` and shows the constructed type. It applied that redirect whenever the cursor was on a `new` whose parent is a `NewExpression`, unconditionally returning `node.parent.expression`:

```ts
if (node.parent && isNewExpression(node.parent) && node.pos === node.parent.pos) {
    return node.parent.expression;
}
```

`NewExpression.expression` is optional. For the string-path clone form `new("/path")`, the path is an **argument**, not the expression — so `expression` is `undefined`. The function returned `undefined`, and the next line `getSymbolAtLocationForQuickInfo(undefined)` dereferenced `node.flags`, throwing.

### Fix

Guard the redirect so it only fires when `expression` actually exists; otherwise fall through to the `new` keyword token:

```ts
if (node.parent && isNewExpression(node.parent) && node.parent.expression && node.pos === node.parent.pos) {
    return node.parent.expression;
}
```

The change is purely additive — the `new Foo()` / `new(class Foo)` paths (where `expression` is defined) are unchanged; only the previously-crashing undefined case is affected. Hovering `new` on a string-path clone now returns no tooltip instead of crashing.

### Tests

New `quickinfo.spec.ts` case asserts hovering `new` on `new("/path")` does not throw. 
