### PR TITLE
Add configurable log verbosity; keep file-watcher chatter out of the normal log

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,18 @@ foo(p); /* p will report an error when strictObjectTypes is true, because it is 
 bar(p); /* this call is ok because both objects are untyped */
 ```
 
+## Extension Settings
+
+The following settings are configured through your editor's settings (e.g. `settings.json`) rather than `lpc-config.json`, as they apply to the language server process rather than an individual mudlib.
+
+| Setting                                  | Default    | Description                                                                                                                                                                          |
+| ---------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LPC.locale`                             | `"auto"`   | The locale used to report LPC errors. Defaults to your editor's display language.                                                                                                   |
+| `LPC.languageServer.maxLpcServerMemory`  | `3072`     | The maximum amount of memory (in MB) to allocate to the language server process.                                                                                                    |
+| `LPC.languageServer.logVerbosity`        | `"normal"` | How much the language server writes to its log: `terse`, `normal`, or `verbose`. Use `verbose` to surface file-watcher activity that is otherwise suppressed when diagnosing watch behavior. |
+
+Changing any of these requires restarting the language server (`LPC: Restart Language Server`) to take effect.
+
 ## Grammar ToDo's
 
 Language services is a work in progress. Some major areas that have yet to be implemented are:

--- a/client/src/configuration/configuration.ts
+++ b/client/src/configuration/configuration.ts
@@ -6,8 +6,13 @@ export abstract class BaseServiceConfigurationProvider {
         return {
             locale: this.readLocale(configuration),
             maxLpcServerMemory: this.readMaxLpcServerMemory(configuration),
+            logVerbosity: this.readLogVerbosity(configuration),
         }
     }
+
+    protected readLogVerbosity(configuration: vscode.WorkspaceConfiguration): string {
+		return configuration.get<string>('LPC.languageServer.logVerbosity', 'normal');
+	}
 
     protected readLocale(configuration: vscode.WorkspaceConfiguration): string | null {
 		const value = configuration.get<string>('LPC.locale', 'auto');
@@ -28,4 +33,5 @@ export abstract class BaseServiceConfigurationProvider {
 export interface LpcServiceConfiguration {
     readonly locale: string | null;
     readonly maxLpcServerMemory: number;
+    readonly logVerbosity: string;
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -78,12 +78,16 @@ export async function activate(context: ExtensionContext) {
     };
 
     const serverArgs = [
-        efunDir, 
-        "--driverType", defaultDriverType, 
+        efunDir,
+        "--driverType", defaultDriverType,
         "--serverMode", "semantic",
         "--locale", configuration.locale ?? vscode.env.language,
+        "--logVerbosity", configuration.logVerbosity,
     ];
-    const syntaxServerArgs = [efunDir, "--driverType", defaultDriverType, "--serverMode", "syntactic"];
+    const syntaxServerArgs = [
+        efunDir, "--driverType", defaultDriverType, "--serverMode", "syntactic",
+        "--logVerbosity", configuration.logVerbosity,
+    ];
 
     // If the extension is launched in debug mode then the debug server options are used
     // Otherwise the run options are used

--- a/package.json
+++ b/package.json
@@ -215,6 +215,22 @@
                     "default": 3072,
                     "description": "The maximum amount of memory (in MB) to allocate to the LPC language server process.",
                     "scope": "window"
+                },
+                "LPC.languageServer.logVerbosity": {
+                    "type": "string",
+                    "default": "normal",
+                    "enum": [
+                        "terse",
+                        "normal",
+                        "verbose"
+                    ],
+                    "enumDescriptions": [
+                        "Errors and essential messages only.",
+                        "Standard logging (default).",
+                        "Everything, including per-event file-watcher activity — noisy."
+                    ],
+                    "markdownDescription": "Controls how much the LPC language server writes to its log. `verbose` surfaces file-watcher breadcrumbs (e.g. save files rewritten each heartbeat) that are otherwise suppressed. Changing this requires restarting the language server.",
+                    "scope": "window"
                 }
             }
         }

--- a/server/src/lpcserver/server.ts
+++ b/server/src/lpcserver/server.ts
@@ -17,7 +17,16 @@ import { MarkdownString } from "./MarkdownString.js";
 // generate a unique 5 digit it
 // const randomId = Math.floor(Math.random() * 90000) + 10000;
 // const logFilename = `lpc-server-${randomId}.log`;
-const logger = new Logger(undefined, true, lpc.server.LogLevel.normal);
+// Log verbosity is controlled by the client via the --logVerbosity launch arg
+// (see the LPC.languageServer.logVerbosity setting). Defaults to normal. verbose
+// surfaces the file-watcher breadcrumbs that are otherwise suppressed.
+const logVerbosityArg = lpc.findArgument("--logVerbosity", process.argv);
+const logLevel =
+    logVerbosityArg === "terse" ? lpc.server.LogLevel.terse :
+    logVerbosityArg === "requestTime" ? lpc.server.LogLevel.requestTime :
+    logVerbosityArg === "verbose" ? lpc.server.LogLevel.verbose :
+    lpc.server.LogLevel.normal;
+const logger = new Logger(undefined, true, logLevel);
 // const origLog = console.log;
 // console.log = (...args) => { logger.info(args.length === 1 ? args[0] : args.join(", ")); origLog(...args); };
 // const origErr = console.error;

--- a/server/src/server/editorServices.ts
+++ b/server/src/server/editorServices.ts
@@ -198,8 +198,11 @@ export class ProjectService {
 
         this.documentRegistry = createDocumentRegistryInternal(this.host.useCaseSensitiveFileNames, this.currentDirectory, this.jsDocParsingMode, this);
 
+        // Watcher trigger/breadcrumb logging is chatty (fires on every filesystem
+        // event, e.g. save files rewritten each heartbeat). Keep it out of the normal
+        // tier so real messages stay findable; surface it only at verbose.
         const watchLogLevel = this.logger.hasLevel(LogLevel.verbose) ? WatchLogLevel.Verbose :
-            this.logger.loggingEnabled() ? WatchLogLevel.TriggerOnly : WatchLogLevel.None;
+            WatchLogLevel.None;
             
         this.watchFactory = this.serverMode !== LanguageServiceMode.Semantic ?
             {
@@ -1266,7 +1269,7 @@ export class ProjectService {
                         options: config.parsedCommandLine!.options,
                         program: configuredProjectForConfig?.getCurrentProgram() || config.parsedCommandLine!.fileNames,
                         useCaseSensitiveFileNames: this.host.useCaseSensitiveFileNames,
-                        writeLog: s => this.logger.info(s),
+                        writeLog: s => { if (this.logger.hasLevel(LogLevel.verbose)) this.logger.info(s); },
                         toPath: s => this.toPath(s),
                         getScriptKind: configuredProjectForConfig ? (fileName => configuredProjectForConfig.getScriptKind(fileName)) : undefined,
                     })


### PR DESCRIPTION
## Problem

The wildcard directory watcher logs a breadcrumb on **every** filesystem event under the workspace — including editor/driver-generated files that get rewritten constantly. For a running MUD lib whose save files (`.o`) are rewritten on every heartbeat, the log fills with lines like:

```
Info 138  Project: .../lpc-config.json Detected file add/remove of non supported extension: .../data/users/g/gesslar/gesslar.o
DirectoryWatcher:: Triggered with .../gesslar.o ...
```

drowning out anything actually worth seeing. `exclude` doesn't help — with the default `include` of `**/*`, the whole root is watched recursively, and these events are only *filtered* per-event (with a log), not un-watched.

These watcher logs also bypassed the existing `LogLevel` system, so there was no way to quiet them without disabling logging entirely:
- the watch factory ran at `WatchLogLevel.TriggerOnly` whenever *any* logging was enabled, and
- the wildcard-ignore `writeLog` was a bare `logger.info()` with no level gate.

The server log level itself was also hardcoded to `LogLevel.normal` with no way to change it.

## Changes

- Gate both the watch factory log level and the wildcard-ignore `writeLog` behind `LogLevel.verbose`, so the `normal` tier stays quiet. Real messages and errors are unaffected.
- Add an `LPC.languageServer.logVerbosity` setting (`terse` | `normal` | `verbose`), plumbed through the client as a `--logVerbosity` launch arg and applied at `Logger` construction — so verbosity is user-configurable instead of hardcoded. `verbose` restores the full watcher breadcrumbs for when you're actually diagnosing watch behavior.
- Document the extension settings (including the two existing ones) in the README.

## Testing

- `npm run compile` — clean
- `npm test` — 16 suites / 880 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)