### PR TITLE
Fix goto-definition & hover on super accessors (e.g. `::create()`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: foreach loop variable type checking [#344](https://github.com/jlchmura/lpc-language-server/pull/344)
 - Fix: allow the `time_expression` efun to be declared in efun definition headers so it keeps completion and lpcdoc support
 - Fix: hovering the `time_expression` keyword now shows the efun signature and lpcdoc
+- Fix: goto-definition and hover on a super accessor (e.g. `::create()`) now resolve to the inherited parent's member instead of the local override
 
 ## 1.1.48
 

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -14801,8 +14801,64 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return errorType;
         }
 
-        // resolve the name
+        // resolve the name against the inherited parent(s) rather than the local scope, so
+        // `::create()` refers to the parent's create and not this file's override.
+        const superMember = getSuperAccessMemberSymbol(node);
+        if (superMember) {
+            getNodeLinks(node.name).resolvedSymbol = superMember;
+            return getTypeOfSymbol(superMember);
+        }
+
+        // fall back to ordinary resolution (e.g. `efun::foo()`, or the member isn't found
+        // on any parent)
         return checkIdentifier(node.name, checkMode);
+    }
+
+    /**
+     * Resolve the member named by a super access (`::name` / `Parent::name`) against the
+     * inherited parent object(s), skipping this file's own members. Returns the inherited
+     * member symbol, or undefined for the efun-prefix form / when no parent declares it.
+     */
+    function getSuperAccessMemberSymbol(node: SuperAccessExpression): Symbol | undefined {
+        const name = node.name;
+        if (nodeIsMissing(name) || !isIdentifier(name)) {
+            return undefined;
+        }
+        // `efun::foo()` targets the efun, not an inherited object -- leave it to normal resolution.
+        if (node.namespace && getTextOfNode(node.namespace) === InternalSymbolName.EfunSuperPrefix) {
+            return undefined;
+        }
+
+        const sourceSymbol = getSymbolOfNode(getSourceFileOfNode(node));
+        const sourceType = getDeclaredTypeOfSymbol(sourceSymbol) as InterfaceType;
+        if (!sourceType) {
+            return undefined;
+        }
+
+        // getBaseTypes of a source-file type includes the file's own type as the first entry;
+        // super access must skip the current file's members, so exclude it.
+        const mergedSourceSymbol = getMergedSymbol(sourceSymbol);
+        const baseTypes = getBaseTypes(sourceType).filter(base => getMergedSymbol(base.symbol) !== mergedSourceSymbol);
+        // `Parent::name` names a specific inherited object -- prefer the matching base.
+        const qualifier = node.namespace && getTextOfNode(node.namespace);
+        if (qualifier) {
+            for (const base of baseTypes) {
+                if (base.symbol && symbolName(base.symbol) === qualifier) {
+                    const prop = getPropertyOfType(base, name.text);
+                    if (prop) {
+                        return prop;
+                    }
+                }
+            }
+        }
+        // Bare `::name` (or an unmatched qualifier): search all direct parents, first match wins.
+        for (const base of baseTypes) {
+            const prop = getPropertyOfType(base, name.text);
+            if (prop) {
+                return prop;
+            }
+        }
+        return undefined;
     }
 
     function hasTypeParameterByName(typeParameters: readonly TypeParameter[] | undefined, name: string) {
@@ -31622,6 +31678,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             SymbolFlags.Value;
             
             if (name.kind === SyntaxKind.Identifier) {
+                // `::name` / `Parent::name` resolves to the inherited parent's member, not
+                // this file's own -- so goto-definition and hover point at the parent.
+                if (isSuperAccessExpression(name.parent) && name.parent.name === name) {
+                    const superMember = getSuperAccessMemberSymbol(name.parent);
+                    if (superMember) {
+                        return superMember;
+                    }
+                }
                 const result = resolveEntityName(name, meaning, /*ignoreErrors*/ true, /*dontResolveAlias*/ true, getHostSignatureFromJSDoc(name));
                 if (!result && isJSDoc) {                    
                     const container = findAncestor(name, or(isClassLike, isInterfaceDeclaration));

--- a/server/src/tests/foreachTypeChecking.spec.ts
+++ b/server/src/tests/foreachTypeChecking.spec.ts
@@ -1,5 +1,5 @@
 import * as lpc from "./_namespaces/lpc.js";
-import * as path from "path";
+import { createTestLanguageService } from "./harness.js";
 
 /**
  * Type checking of the `foreach` loop variables.
@@ -16,50 +16,7 @@ import * as path from "path";
  *    array's index type.
  */
 function createLanguageService(options: lpc.CompilerOptions, fileText: Record<string, string>) {
-    const cwd = lpc.normalizePath(process.cwd());
-    const toAbs = (rel: string) => lpc.normalizePath(path.join(cwd, rel));
-
-    const files = new Map<string, string>();
-    for (const rel of Object.keys(fileText)) files.set(toAbs(rel), fileText[rel]);
-
-    const scriptFiles = Array.from(files.keys());
-    const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
-    const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
-    const norm = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
-
-    const host: lpc.LanguageServiceHost = {
-        getCompilationSettings: () => options,
-        getCurrentDirectory: () => cwd,
-        getDefaultLibFileName: (opts) =>
-            lpc.combinePaths(cwd, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
-        getIncludeDirs: () => [],
-        getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, cwd, getCanonicalFileName))),
-        getScriptFileNames: () => scriptFiles,
-        getScriptSnapshot: (name) => {
-            const n = norm(name);
-            if (!n) return undefined;
-            const text = files.get(n) ?? lpc.sys.readFile(n);
-            return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
-        },
-        getScriptVersion: () => "1",
-        isKnownTypesPackageName: () => false,
-        useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
-        fileExists: (name) => { const n = norm(name); return !!n && (files.has(n) || lpc.sys.fileExists(n)); },
-        readFile: (name) => { const n = norm(name); return n ? files.get(n) ?? lpc.sys.readFile(n) : undefined; },
-        onAllFilesNeedReparse: () => undefined,
-        onReleaseOldSourceFile: () => undefined,
-        onReleaseParsedCommandLine: () => undefined,
-    };
-
-    const fileHandler = lpc.createLpcFileHandler({
-        fileExists: (name) => host.fileExists(name),
-        readFile: (name) => host.readFile(name),
-        getIncludeDirs: () => host.getIncludeDirs(),
-        getCompilerOptions: () => host.getCompilationSettings(),
-        getCurrentDirectory: () => host.getCurrentDirectory(),
-    });
-
-    return { ls: lpc.createLanguageService(host, fileHandler), abs: toAbs };
+    return createTestLanguageService(fileText, options);
 }
 
 function messagesFor(source: string): string[] {

--- a/server/src/tests/harness.ts
+++ b/server/src/tests/harness.ts
@@ -1,0 +1,85 @@
+import * as lpc from "./_namespaces/lpc.js";
+import * as path from "path";
+
+/**
+ * Shared test harness for building a `LanguageService` over an in-memory file set.
+ *
+ * Every LS-driven spec used to hand-roll ~50 lines of identical `LanguageServiceHost`
+ * boilerplate; this consolidates it. Files are keyed by workspace-relative path and
+ * resolved against `process.cwd()`. Any path not in `files` falls through to the real
+ * filesystem, so the driver's default efun library loads normally.
+ */
+
+export interface TestLanguageService {
+    ls: lpc.LanguageService;
+    /** Absolute, normalized path for a workspace-relative file name. */
+    abs: (rel: string) => string;
+    /** Absolute path of the first entry in `files` -- convenient for single-file specs. */
+    fileName: string;
+}
+
+/** Absolute, normalized path for a workspace-relative file name (matches the harness). */
+export function testFilePath(rel: string): string {
+    return lpc.normalizePath(path.join(lpc.normalizePath(process.cwd()), rel));
+}
+
+const DEFAULT_OPTIONS: lpc.CompilerOptions = {
+    driverType: lpc.LanguageVariant.FluffOS,
+    diagnostics: true,
+};
+
+export function createTestLanguageService(
+    files: Record<string, string>,
+    options?: Partial<lpc.CompilerOptions>,
+): TestLanguageService {
+    const cwd = lpc.normalizePath(process.cwd());
+    const abs = (rel: string) => lpc.normalizePath(path.join(cwd, rel));
+    const norm = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
+
+    const fileText = new Map<string, string>();
+    for (const rel of Object.keys(files)) fileText.set(abs(rel), files[rel]);
+
+    const scriptFiles = Array.from(fileText.keys());
+    const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
+    const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
+
+    const compilerOptions: lpc.CompilerOptions = { ...DEFAULT_OPTIONS, ...options };
+
+    const host: lpc.LanguageServiceHost = {
+        getCompilationSettings: () => compilerOptions,
+        getCurrentDirectory: () => cwd,
+        getDefaultLibFileName: (opts) =>
+            lpc.combinePaths(cwd, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
+        getIncludeDirs: () => [],
+        getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, cwd, getCanonicalFileName))),
+        getScriptFileNames: () => scriptFiles,
+        getScriptSnapshot: (name) => {
+            const n = norm(name);
+            if (!n) return undefined;
+            const text = fileText.get(n) ?? lpc.sys.readFile(n);
+            return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
+        },
+        getScriptVersion: () => "1",
+        isKnownTypesPackageName: () => false,
+        useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
+        fileExists: (name) => { const n = norm(name); return !!n && (fileText.has(n) || lpc.sys.fileExists(n)); },
+        readFile: (name) => { const n = norm(name); return n ? fileText.get(n) ?? lpc.sys.readFile(n) : undefined; },
+        onAllFilesNeedReparse: () => undefined,
+        onReleaseOldSourceFile: () => undefined,
+        onReleaseParsedCommandLine: () => undefined,
+    };
+
+    const fileHandler = lpc.createLpcFileHandler({
+        fileExists: (name) => host.fileExists(name),
+        readFile: (name) => host.readFile(name),
+        getIncludeDirs: () => host.getIncludeDirs(),
+        getCompilerOptions: () => host.getCompilationSettings(),
+        getCurrentDirectory: () => host.getCurrentDirectory(),
+    });
+
+    return {
+        ls: lpc.createLanguageService(host, fileHandler),
+        abs,
+        fileName: scriptFiles[0],
+    };
+}

--- a/server/src/tests/navigateTo.spec.ts
+++ b/server/src/tests/navigateTo.spec.ts
@@ -1,5 +1,5 @@
 import * as lpc from "./_namespaces/lpc.js";
-import * as path from "path";
+import { createTestLanguageService } from "./harness.js";
 
 /**
  * Workspace-symbol ("navigate to") search. Two layers are covered:
@@ -13,65 +13,7 @@ import * as path from "path";
  */
 
 function createLanguageService(source: string) {
-    const fileName = lpc.normalizePath(path.join(process.cwd(), "navto.c"));
-
-    const options: lpc.CompilerOptions = {
-        driverType: lpc.LanguageVariant.FluffOS,
-        diagnostics: true,
-    };
-
-    const scriptFiles = [fileName];
-    const fileText = new Map<string, string>([[fileName, source]]);
-    const scriptVersions = new Map<string, string>([[fileName, "1"]]);
-
-    const currentDirectory = lpc.normalizePath(process.cwd());
-    const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
-    const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
-    const normalizeHostFileName = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
-
-    const host: lpc.LanguageServiceHost = {
-        getCompilationSettings: () => options,
-        getCurrentDirectory: () => currentDirectory,
-        getDefaultLibFileName: (opts) =>
-            lpc.combinePaths(currentDirectory, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
-        getIncludeDirs: () => [],
-        getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, currentDirectory, getCanonicalFileName))),
-        getScriptFileNames: () => scriptFiles,
-        getScriptSnapshot: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            if (!normalizedName) return undefined;
-            const text = fileText.get(normalizedName) ?? lpc.sys.readFile(normalizedName);
-            return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
-        },
-        getScriptVersion: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            return normalizedName ? scriptVersions.get(normalizedName) ?? "0" : "0";
-        },
-        isKnownTypesPackageName: () => false,
-        useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
-        fileExists: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            return !!normalizedName && (fileText.has(normalizedName) || lpc.sys.fileExists(normalizedName));
-        },
-        readFile: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            return normalizedName ? fileText.get(normalizedName) ?? lpc.sys.readFile(normalizedName) : undefined;
-        },
-        onAllFilesNeedReparse: () => undefined,
-        onReleaseOldSourceFile: () => undefined,
-        onReleaseParsedCommandLine: () => undefined,
-    };
-
-    const fileHandler = lpc.createLpcFileHandler({
-        fileExists: (name) => host.fileExists(name),
-        readFile: (name) => host.readFile(name),
-        getIncludeDirs: () => host.getIncludeDirs(),
-        getCompilerOptions: () => host.getCompilationSettings(),
-        getCurrentDirectory: () => host.getCurrentDirectory(),
-    });
-
-    const ls = lpc.createLanguageService(host, fileHandler);
-    return { ls, fileName };
+    return createTestLanguageService({ "navto.c": source });
 }
 
 // Distinctive names so matches can't collide with declarations in the driver's built-in libs.

--- a/server/src/tests/quickinfo.spec.ts
+++ b/server/src/tests/quickinfo.spec.ts
@@ -1,67 +1,8 @@
 import * as lpc from "./_namespaces/lpc.js";
-import * as path from "path";
+import { createTestLanguageService } from "./harness.js";
 
 function createLanguageService(source: string) {
-    const fileName = lpc.normalizePath(path.join(process.cwd(), "test.c"));
-
-    const options: lpc.CompilerOptions = {
-        driverType: lpc.LanguageVariant.FluffOS,
-        diagnostics: true,
-    };
-
-    const scriptFiles = [fileName];
-    const fileText = new Map<string, string>([[fileName, source]]);
-    const scriptVersions = new Map<string, string>([[fileName, "1"]]);
-
-    const currentDirectory = lpc.normalizePath(process.cwd());
-    const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
-    const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
-    const normalizeHostFileName = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
-
-    const host: lpc.LanguageServiceHost = {
-        getCompilationSettings: () => options,
-        getCurrentDirectory: () => currentDirectory,
-        getDefaultLibFileName: (opts) =>
-            lpc.combinePaths(currentDirectory, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
-        getIncludeDirs: () => [],
-        getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, currentDirectory, getCanonicalFileName))),
-        getScriptFileNames: () => scriptFiles,
-        getScriptSnapshot: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            if (!normalizedName) return undefined;
-            const text = fileText.get(normalizedName) ?? lpc.sys.readFile(normalizedName);
-            return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
-        },
-        getScriptVersion: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            return normalizedName ? scriptVersions.get(normalizedName) ?? "0" : "0";
-        },
-        isKnownTypesPackageName: () => false,
-        useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
-        fileExists: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            return !!normalizedName && (fileText.has(normalizedName) || lpc.sys.fileExists(normalizedName));
-        },
-        readFile: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            return normalizedName ? fileText.get(normalizedName) ?? lpc.sys.readFile(normalizedName) : undefined;
-        },
-        onAllFilesNeedReparse: () => undefined,
-        onReleaseOldSourceFile: () => undefined,
-        onReleaseParsedCommandLine: () => undefined,
-    };
-
-    const fileHandler = lpc.createLpcFileHandler({
-        fileExists: (name) => host.fileExists(name),
-        readFile: (name) => host.readFile(name),
-        getIncludeDirs: () => host.getIncludeDirs(),
-        getCompilerOptions: () => host.getCompilationSettings(),
-        getCurrentDirectory: () => host.getCurrentDirectory(),
-    });
-
-    const ls = lpc.createLanguageService(host, fileHandler);
-
-    return { ls, fileName };
+    return createTestLanguageService({ "test.c": source });
 }
 
 function getDisplayString(quickInfo: lpc.QuickInfo): string {

--- a/server/src/tests/renameEvaluateExpression.spec.ts
+++ b/server/src/tests/renameEvaluateExpression.spec.ts
@@ -1,9 +1,8 @@
 import * as lpc from "./_namespaces/lpc.js";
-import * as path from "path";
+import { createTestLanguageService } from "./harness.js";
 
 describe("LanguageService", () => {
     it("includes EvaluateExpression arguments in findReferences/findRenameLocations", () => {
-        const fileName = lpc.normalizePath(path.join(process.cwd(), "test.c"));
         const source = `test(object who) {
     fn(who);
 
@@ -14,62 +13,7 @@ describe("LanguageService", () => {
 fn(object o) {}
 `;
 
-        const options: lpc.CompilerOptions = {
-            driverType: lpc.LanguageVariant.FluffOS,
-            diagnostics: true,
-        };
-
-        const scriptFiles = [fileName];
-        const fileText = new Map<string, string>([[fileName, source]]);
-        const scriptVersions = new Map<string, string>([[fileName, "1"]]);
-
-        const currentDirectory = lpc.normalizePath(process.cwd());
-        const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
-        const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
-        const normalizeHostFileName = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
-
-        const host: lpc.LanguageServiceHost = {
-            getCompilationSettings: () => options,
-            getCurrentDirectory: () => currentDirectory,
-            getDefaultLibFileName: (opts) =>
-                lpc.combinePaths(currentDirectory, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
-            getIncludeDirs: () => [],
-            getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, currentDirectory, getCanonicalFileName))),
-            getScriptFileNames: () => scriptFiles,
-            getScriptSnapshot: (name) => {
-                const normalizedName = normalizeHostFileName(name);
-                if (!normalizedName) return undefined;
-                const text = fileText.get(normalizedName) ?? lpc.sys.readFile(normalizedName);
-                return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
-            },
-            getScriptVersion: (name) => {
-                const normalizedName = normalizeHostFileName(name);
-                return normalizedName ? scriptVersions.get(normalizedName) ?? "0" : "0";
-            },
-            isKnownTypesPackageName: () => false,
-            useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
-            fileExists: (name) => {
-                const normalizedName = normalizeHostFileName(name);
-                return !!normalizedName && (fileText.has(normalizedName) || lpc.sys.fileExists(normalizedName));
-            },
-            readFile: (name) => {
-                const normalizedName = normalizeHostFileName(name);
-                return normalizedName ? fileText.get(normalizedName) ?? lpc.sys.readFile(normalizedName) : undefined;
-            },
-            onAllFilesNeedReparse: () => undefined,
-            onReleaseOldSourceFile: () => undefined,
-            onReleaseParsedCommandLine: () => undefined,
-        };
-
-        const fileHandler = lpc.createLpcFileHandler({
-            fileExists: (name) => host.fileExists(name),
-            readFile: (name) => host.readFile(name),
-            getIncludeDirs: () => host.getIncludeDirs(),
-            getCompilerOptions: () => host.getCompilationSettings(),
-            getCurrentDirectory: () => host.getCurrentDirectory(),
-        });
-
-        const ls = lpc.createLanguageService(host, fileHandler);
+        const { ls, fileName } = createTestLanguageService({ "test.c": source });
 
         const declPos = source.indexOf("who");
         const evalArgPos = source.lastIndexOf("who");

--- a/server/src/tests/renameGlobalVarScope.spec.ts
+++ b/server/src/tests/renameGlobalVarScope.spec.ts
@@ -1,70 +1,14 @@
 import * as lpc from "./_namespaces/lpc.js";
-import * as path from "path";
+import { createTestLanguageService } from "./harness.js";
 
-function makeLanguageService(files: Map<string, string>) {
-    const options: lpc.CompilerOptions = {
-        driverType: lpc.LanguageVariant.FluffOS,
-        diagnostics: true,
-    };
-
-    const scriptFiles = [...files.keys()];
-    const scriptVersions = new Map<string, string>(scriptFiles.map((f) => [f, "1"]));
-
-    const currentDirectory = lpc.normalizePath(process.cwd());
-    const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
-    const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
-    const normalizeHostFileName = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
-
-    const host: lpc.LanguageServiceHost = {
-        getCompilationSettings: () => options,
-        getCurrentDirectory: () => currentDirectory,
-        getDefaultLibFileName: (opts) =>
-            lpc.combinePaths(currentDirectory, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
-        getIncludeDirs: () => [],
-        getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, currentDirectory, getCanonicalFileName))),
-        getScriptFileNames: () => scriptFiles,
-        getScriptSnapshot: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            if (!normalizedName) return undefined;
-            const text = files.get(normalizedName) ?? lpc.sys.readFile(normalizedName);
-            return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
-        },
-        getScriptVersion: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            return normalizedName ? scriptVersions.get(normalizedName) ?? "0" : "0";
-        },
-        isKnownTypesPackageName: () => false,
-        useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
-        fileExists: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            return !!normalizedName && (files.has(normalizedName) || lpc.sys.fileExists(normalizedName));
-        },
-        readFile: (name) => {
-            const normalizedName = normalizeHostFileName(name);
-            return normalizedName ? files.get(normalizedName) ?? lpc.sys.readFile(normalizedName) : undefined;
-        },
-        onAllFilesNeedReparse: () => undefined,
-        onReleaseOldSourceFile: () => undefined,
-        onReleaseParsedCommandLine: () => undefined,
-    };
-
-    const fileHandler = lpc.createLpcFileHandler({
-        fileExists: (name) => host.fileExists(name),
-        readFile: (name) => host.readFile(name),
-        getIncludeDirs: () => host.getIncludeDirs(),
-        getCompilerOptions: () => host.getCompilationSettings(),
-        getCurrentDirectory: () => host.getCurrentDirectory(),
-    });
-
-    const ls = lpc.createLanguageService(host, fileHandler);
-
+function makeLanguageService(files: Record<string, string>) {
+    const svc = createTestLanguageService(files);
     // force check every file so LPC inherits are resolved
-    const program = ls.getProgram()!;
-    for (const f of scriptFiles) {
-        program.getTypeChecker().getDiagnostics(program.getSourceFile(f));
+    const program = svc.ls.getProgram()!;
+    for (const rel of Object.keys(files)) {
+        program.getTypeChecker().getDiagnostics(program.getSourceFile(svc.abs(rel)));
     }
-
-    return ls;
+    return svc;
 }
 
 function renameCountsByFile(ls: lpc.LanguageService, fileName: string, pos: number) {
@@ -78,8 +22,6 @@ function renameCountsByFile(ls: lpc.LanguageService, fileName: string, pos: numb
 
 describe("LanguageService rename global var scope", () => {
     it("does not rename same-named globals in unrelated files", () => {
-        const fileA = lpc.normalizePath(path.join(process.cwd(), "a.c"));
-        const fileB = lpc.normalizePath(path.join(process.cwd(), "b.c"));
         const sourceA = `int foo;
 
 test() {
@@ -94,7 +36,9 @@ other() {
     return foo;
 }
 `;
-        const ls = makeLanguageService(new Map([[fileA, sourceA], [fileB, sourceB]]));
+        const { ls, abs } = makeLanguageService({ "a.c": sourceA, "b.c": sourceB });
+        const fileA = abs("a.c");
+        const fileB = abs("b.c");
 
         const declPos = sourceA.indexOf("foo");
         const byFile = renameCountsByFile(ls, fileA, declPos);
@@ -104,8 +48,6 @@ other() {
     });
 
     it("renames inherited global var references in child files", () => {
-        const parent = lpc.normalizePath(path.join(process.cwd(), "parent.c"));
-        const child = lpc.normalizePath(path.join(process.cwd(), "child.c"));
         const sourceParent = `int foo;
 
 test() {
@@ -120,7 +62,9 @@ child_fn() {
     return foo;
 }
 `;
-        const ls = makeLanguageService(new Map([[parent, sourceParent], [child, sourceChild]]));
+        const { ls, abs } = makeLanguageService({ "parent.c": sourceParent, "child.c": sourceChild });
+        const parent = abs("parent.c");
+        const child = abs("child.c");
 
         const declPos = sourceParent.indexOf("foo");
         const byFile = renameCountsByFile(ls, parent, declPos);

--- a/server/src/tests/sefunUndeclaredEfunShadow.spec.ts
+++ b/server/src/tests/sefunUndeclaredEfunShadow.spec.ts
@@ -1,5 +1,5 @@
 import * as lpc from "./_namespaces/lpc.js";
-import * as path from "path";
+import { createTestLanguageService, testFilePath } from "./harness.js";
 
 /**
  * End-to-end regression for the "phantom simul_efun shadows a real efun" bug.
@@ -17,57 +17,7 @@ import * as path from "path";
  *     '"Gobbledygook in string.\n"'.
  */
 function createLanguageService(files: Record<string, string>, sefunRelPath: string) {
-    const cwd = lpc.normalizePath(process.cwd());
-    const toAbs = (rel: string) => lpc.normalizePath(path.join(cwd, rel));
-
-    const fileText = new Map<string, string>();
-    for (const rel of Object.keys(files)) fileText.set(toAbs(rel), files[rel]);
-
-    const scriptFiles = Array.from(fileText.keys());
-    const scriptVersions = new Map<string, string>(scriptFiles.map(f => [f, "1"]));
-    const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
-    const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
-    const norm = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
-
-    const options: lpc.CompilerOptions = {
-        driverType: lpc.LanguageVariant.FluffOS,
-        diagnostics: true,
-        sefunFile: toAbs(sefunRelPath),
-    };
-
-    const host: lpc.LanguageServiceHost = {
-        getCompilationSettings: () => options,
-        getCurrentDirectory: () => cwd,
-        getDefaultLibFileName: (opts) =>
-            lpc.combinePaths(cwd, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
-        getIncludeDirs: () => [],
-        getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, cwd, getCanonicalFileName))),
-        getScriptFileNames: () => scriptFiles,
-        getScriptSnapshot: (name) => {
-            const n = norm(name);
-            if (!n) return undefined;
-            const text = fileText.get(n) ?? lpc.sys.readFile(n);
-            return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
-        },
-        getScriptVersion: (name) => (norm(name) ? scriptVersions.get(norm(name)!) ?? "0" : "0"),
-        isKnownTypesPackageName: () => false,
-        useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
-        fileExists: (name) => { const n = norm(name); return !!n && (fileText.has(n) || lpc.sys.fileExists(n)); },
-        readFile: (name) => { const n = norm(name); return n ? fileText.get(n) ?? lpc.sys.readFile(n) : undefined; },
-        onAllFilesNeedReparse: () => undefined,
-        onReleaseOldSourceFile: () => undefined,
-        onReleaseParsedCommandLine: () => undefined,
-    };
-
-    const fileHandler = lpc.createLpcFileHandler({
-        fileExists: (name) => host.fileExists(name),
-        readFile: (name) => host.readFile(name),
-        getIncludeDirs: () => host.getIncludeDirs(),
-        getCompilerOptions: () => host.getCompilationSettings(),
-        getCurrentDirectory: () => host.getCurrentDirectory(),
-    });
-
-    return { ls: lpc.createLanguageService(host, fileHandler), abs: toAbs };
+    return createTestLanguageService(files, { sefunFile: testFilePath(sefunRelPath) });
 }
 
 // Condensed from the mudlib's from_string(): an inline function early in the

--- a/server/src/tests/superAccessResolution.spec.ts
+++ b/server/src/tests/superAccessResolution.spec.ts
@@ -1,5 +1,4 @@
-import * as lpc from "./_namespaces/lpc.js";
-import * as path from "path";
+import { createTestLanguageService } from "./harness.js";
 
 /**
  * Regression for `::name` (super access) resolution.
@@ -9,56 +8,7 @@ import * as path from "path";
  * which is what a plain lexical scope walk would find first.
  */
 function createLanguageService(files: Record<string, string>) {
-    const cwd = lpc.normalizePath(process.cwd());
-    const toAbs = (rel: string) => lpc.normalizePath(path.join(cwd, rel));
-
-    const fileText = new Map<string, string>();
-    for (const rel of Object.keys(files)) fileText.set(toAbs(rel), files[rel]);
-
-    const scriptFiles = Array.from(fileText.keys());
-    const scriptVersions = new Map<string, string>(scriptFiles.map(f => [f, "1"]));
-    const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
-    const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
-    const norm = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
-
-    const options: lpc.CompilerOptions = {
-        driverType: lpc.LanguageVariant.FluffOS,
-        diagnostics: true,
-    };
-
-    const host: lpc.LanguageServiceHost = {
-        getCompilationSettings: () => options,
-        getCurrentDirectory: () => cwd,
-        getDefaultLibFileName: (opts) =>
-            lpc.combinePaths(cwd, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
-        getIncludeDirs: () => [],
-        getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, cwd, getCanonicalFileName))),
-        getScriptFileNames: () => scriptFiles,
-        getScriptSnapshot: (name) => {
-            const n = norm(name);
-            if (!n) return undefined;
-            const text = fileText.get(n) ?? lpc.sys.readFile(n);
-            return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
-        },
-        getScriptVersion: (name) => (norm(name) ? scriptVersions.get(norm(name)!) ?? "0" : "0"),
-        isKnownTypesPackageName: () => false,
-        useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
-        fileExists: (name) => { const n = norm(name); return !!n && (fileText.has(n) || lpc.sys.fileExists(n)); },
-        readFile: (name) => { const n = norm(name); return n ? fileText.get(n) ?? lpc.sys.readFile(n) : undefined; },
-        onAllFilesNeedReparse: () => undefined,
-        onReleaseOldSourceFile: () => undefined,
-        onReleaseParsedCommandLine: () => undefined,
-    };
-
-    const fileHandler = lpc.createLpcFileHandler({
-        fileExists: (name) => host.fileExists(name),
-        readFile: (name) => host.readFile(name),
-        getIncludeDirs: () => host.getIncludeDirs(),
-        getCompilerOptions: () => host.getCompilationSettings(),
-        getCurrentDirectory: () => host.getCurrentDirectory(),
-    });
-
-    return { ls: lpc.createLanguageService(host, fileHandler), abs: toAbs };
+    return createTestLanguageService(files);
 }
 
 const parent = `/** parent create */

--- a/server/src/tests/superAccessResolution.spec.ts
+++ b/server/src/tests/superAccessResolution.spec.ts
@@ -1,0 +1,136 @@
+import * as lpc from "./_namespaces/lpc.js";
+import * as path from "path";
+
+/**
+ * Regression for `::name` (super access) resolution.
+ *
+ * `::create()` calls the INHERITED parent's create(), so goto-definition and hover on it
+ * must resolve to the parent file's declaration -- not this file's own create() override,
+ * which is what a plain lexical scope walk would find first.
+ */
+function createLanguageService(files: Record<string, string>) {
+    const cwd = lpc.normalizePath(process.cwd());
+    const toAbs = (rel: string) => lpc.normalizePath(path.join(cwd, rel));
+
+    const fileText = new Map<string, string>();
+    for (const rel of Object.keys(files)) fileText.set(toAbs(rel), files[rel]);
+
+    const scriptFiles = Array.from(fileText.keys());
+    const scriptVersions = new Map<string, string>(scriptFiles.map(f => [f, "1"]));
+    const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
+    const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
+    const norm = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
+
+    const options: lpc.CompilerOptions = {
+        driverType: lpc.LanguageVariant.FluffOS,
+        diagnostics: true,
+    };
+
+    const host: lpc.LanguageServiceHost = {
+        getCompilationSettings: () => options,
+        getCurrentDirectory: () => cwd,
+        getDefaultLibFileName: (opts) =>
+            lpc.combinePaths(cwd, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
+        getIncludeDirs: () => [],
+        getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, cwd, getCanonicalFileName))),
+        getScriptFileNames: () => scriptFiles,
+        getScriptSnapshot: (name) => {
+            const n = norm(name);
+            if (!n) return undefined;
+            const text = fileText.get(n) ?? lpc.sys.readFile(n);
+            return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
+        },
+        getScriptVersion: (name) => (norm(name) ? scriptVersions.get(norm(name)!) ?? "0" : "0"),
+        isKnownTypesPackageName: () => false,
+        useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
+        fileExists: (name) => { const n = norm(name); return !!n && (fileText.has(n) || lpc.sys.fileExists(n)); },
+        readFile: (name) => { const n = norm(name); return n ? fileText.get(n) ?? lpc.sys.readFile(n) : undefined; },
+        onAllFilesNeedReparse: () => undefined,
+        onReleaseOldSourceFile: () => undefined,
+        onReleaseParsedCommandLine: () => undefined,
+    };
+
+    const fileHandler = lpc.createLpcFileHandler({
+        fileExists: (name) => host.fileExists(name),
+        readFile: (name) => host.readFile(name),
+        getIncludeDirs: () => host.getIncludeDirs(),
+        getCompilerOptions: () => host.getCompilationSettings(),
+        getCurrentDirectory: () => host.getCurrentDirectory(),
+    });
+
+    return { ls: lpc.createLanguageService(host, fileHandler), abs: toAbs };
+}
+
+const parent = `/** parent create */
+void create () {
+}
+`;
+
+const child = `inherit "npc";
+
+/** child create */
+void create () {
+    ::create();
+}
+`;
+
+const files = { "npc.c": parent, "snail.c": child };
+
+describe("super access (::name) resolution", () => {
+    it("goto-definition on ::create() jumps to the inherited parent, not the local override", () => {
+        const { ls, abs } = createLanguageService(files);
+        const childText = child;
+        // position on the `create` inside `::create()`
+        const pos = childText.indexOf("::create()") + 2;
+        const defs = ls.getDefinitionAtPosition(abs("snail.c"), pos);
+
+        expect(defs).toBeDefined();
+        expect(defs!.length).toBeGreaterThan(0);
+        // must resolve into the parent file, not the child
+        expect(defs!.every(d => d.fileName.endsWith("npc.c"))).toBe(true);
+        expect(defs!.some(d => d.fileName.endsWith("snail.c"))).toBe(false);
+    });
+
+    it("hover on ::create() shows the parent's lpcdoc, not the child's", () => {
+        const { ls, abs } = createLanguageService(files);
+        const pos = child.indexOf("::create()") + 2;
+        const qi = ls.getQuickInfoAtPosition(abs("snail.c"), pos);
+
+        expect(qi).toBeDefined();
+        const doc = qi!.documentation?.map(d => d.text).join("") ?? "";
+        expect(doc).toContain("parent create");
+        expect(doc).not.toContain("child create");
+    });
+
+    it("a plain (non-super) create() call still resolves locally", () => {
+        // Guard: the super fix must not divert ordinary member resolution to the parent.
+        const localCaller = `inherit "npc";
+
+/** child create */
+void create () {
+    create();
+}
+`;
+        const { ls, abs } = createLanguageService({ "npc.c": parent, "snail.c": localCaller });
+        // the second "create(" is the plain call inside the body
+        const pos = localCaller.indexOf("create();") + 2;
+        const defs = ls.getDefinitionAtPosition(abs("snail.c"), pos);
+
+        expect(defs).toBeDefined();
+        expect(defs!.some(d => d.fileName.endsWith("snail.c"))).toBe(true);
+    });
+
+    it("resolves ::create() up a multi-level inherit chain", () => {
+        // base <- mid <- leaf; leaf's ::create() targets mid, and mid's ::create() targets base.
+        const base = `/** base create */\nvoid create () {\n}\n`;
+        const mid = `inherit "base";\n/** mid create */\nvoid create () {\n    ::create();\n}\n`;
+        const leaf = `inherit "mid";\n/** leaf create */\nvoid create () {\n    ::create();\n}\n`;
+        const { ls, abs } = createLanguageService({ "base.c": base, "mid.c": mid, "leaf.c": leaf });
+
+        const leafDefs = ls.getDefinitionAtPosition(abs("leaf.c"), leaf.indexOf("::create()") + 2);
+        expect(leafDefs!.every(d => d.fileName.endsWith("mid.c"))).toBe(true);
+
+        const midDefs = ls.getDefinitionAtPosition(abs("mid.c"), mid.indexOf("::create()") + 2);
+        expect(midDefs!.every(d => d.fileName.endsWith("base.c"))).toBe(true);
+    });
+});

--- a/server/src/tests/undeclaredAssignment.spec.ts
+++ b/server/src/tests/undeclaredAssignment.spec.ts
@@ -1,5 +1,5 @@
 import * as lpc from "./_namespaces/lpc.js";
-import * as path from "path";
+import { createTestLanguageService } from "./harness.js";
 
 /**
  * Assigning to an undeclared variable.
@@ -10,50 +10,7 @@ import * as path from "path";
  * strictness with the `allowUndeclaredAssignmentsInLd: false` compiler option.
  */
 function createLanguageService(options: lpc.CompilerOptions, fileText: Record<string, string>) {
-    const cwd = lpc.normalizePath(process.cwd());
-    const toAbs = (rel: string) => lpc.normalizePath(path.join(cwd, rel));
-
-    const files = new Map<string, string>();
-    for (const rel of Object.keys(fileText)) files.set(toAbs(rel), fileText[rel]);
-
-    const scriptFiles = Array.from(files.keys());
-    const useCaseSensitiveFileNames = lpc.sys.useCaseSensitiveFileNames;
-    const getCanonicalFileName = lpc.createGetCanonicalFileName(useCaseSensitiveFileNames);
-    const norm = (name: string | undefined) => (name ? lpc.normalizePath(name) : name);
-
-    const host: lpc.LanguageServiceHost = {
-        getCompilationSettings: () => options,
-        getCurrentDirectory: () => cwd,
-        getDefaultLibFileName: (opts) =>
-            lpc.combinePaths(cwd, lpc.getDefaultLibFolder(opts), lpc.getDefaultLibFileName(opts)),
-        getIncludeDirs: () => [],
-        getParseableFiles: () => new Set(scriptFiles.map((f) => lpc.toPath(f, cwd, getCanonicalFileName))),
-        getScriptFileNames: () => scriptFiles,
-        getScriptSnapshot: (name) => {
-            const n = norm(name);
-            if (!n) return undefined;
-            const text = files.get(n) ?? lpc.sys.readFile(n);
-            return text === undefined ? undefined : lpc.ScriptSnapshot.fromString(text);
-        },
-        getScriptVersion: () => "1",
-        isKnownTypesPackageName: () => false,
-        useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
-        fileExists: (name) => { const n = norm(name); return !!n && (files.has(n) || lpc.sys.fileExists(n)); },
-        readFile: (name) => { const n = norm(name); return n ? files.get(n) ?? lpc.sys.readFile(n) : undefined; },
-        onAllFilesNeedReparse: () => undefined,
-        onReleaseOldSourceFile: () => undefined,
-        onReleaseParsedCommandLine: () => undefined,
-    };
-
-    const fileHandler = lpc.createLpcFileHandler({
-        fileExists: (name) => host.fileExists(name),
-        readFile: (name) => host.readFile(name),
-        getIncludeDirs: () => host.getIncludeDirs(),
-        getCompilerOptions: () => host.getCompilationSettings(),
-        getCurrentDirectory: () => host.getCurrentDirectory(),
-    });
-
-    return { ls: lpc.createLanguageService(host, fileHandler), abs: toAbs };
+    return createTestLanguageService(fileText, options);
 }
 
 const source = `void f() {\n    foo = 1;\n}\n`;


### PR DESCRIPTION
### Summary

Goto-definition and hover on an LPC super accessor like `::create()` incorrectly resolved to the **local** `create()` in the same file instead of the **inherited parent's** `create()`. Definitions jumped to the wrong file and hover showed the wrong lpcdoc.

### Repro

```lpc
// snail.c
inherit STD_NPC;   // -> std/npc.c

/** snail create */
void create () {
    ::create();     // goto-def / hover here
}
```

Goto-def on `::create()` landed on `snail.c`'s own `create()`; hover showed the snail's lpcdoc, both instead of the inherited `std/npc.c` `create()`.

### Root cause

Super-access resolution never actually consulted the parent. Both resolution paths — `checkSuperExpression` (hover type) and `getSymbolOfNameOrPropertyAccessExpression` (goto-def / hover symbol) — resolved the member name with a plain lexical scope walk (`resolveName` / `checkIdentifier`), which finds the local `create` first. The `::` semantics (skip self, search parents) and the optional `Parent::` qualifier were ignored. A stale `// TODO: detect super here` in `goToDefinition.ts` confirmed it was never implemented.

### Fix

A shared helper `getSuperAccessMemberSymbol` resolves the member against the inherited parents via `getBaseTypes` + `getPropertyOfType`, wired into both resolution paths.

The non-obvious part: `getBaseTypes(sourceType)` returns the file's **own** type as the first entry (`[snail, npc]`), so a naive "first base wins" search still found the local override. The helper filters out the self type (`getMergedSymbol(base.symbol) !== mergedSourceSymbol`) before searching — which is exactly the "skip the current file" semantics `::` requires.

It also:
- honors a `Parent::name` qualifier by preferring the base whose symbol name matches, falling back to an all-parents search;
- leaves `efun::foo()` (the efun-prefix form) to normal resolution;
- falls back to the previous behavior when no parent declares the member, so nothing regresses.

### Tests

New `superAccessResolution.spec.ts`, all green:
- goto-def on `::create()` lands in the parent file, never the child;
- hover shows the parent's lpcdoc, not the child's;
- a plain (non-super) `create()` call still resolves locally (guard against over-diverting);
- a 3-level inherit chain resolves each `::create()` to its correct direct ancestor.


### Known limitation

Qualifier matching compares the namespace text to the base symbol's name. When the qualifier is a macro (e.g. `STD_NPC::create()`), it won't string-match the resolved base symbol, so it falls through to the all-parents search — which still resolves correctly as long as only one parent declares the member. Exact macro-qualified disambiguation across multiple parents that declare the same method is a follow-up; the common bare `::create()` case is fully fixed.