### PR TITLE
Add the 3-argument form of function_exists to the FluffOS efun stubs

### DIFF
--- a/efuns/fluffos/system.h
+++ b/efuns/fluffos/system.h
@@ -264,11 +264,16 @@ mapping *function_profile( object ob );
 object
  * @param str the name of the function to check for
  * @param ob the object to check in
+ * @param flag if nonzero, protected and private functions are reported as well
  * @returns the file name of the object that defines the function  'str'  in
  * object  'ob'.  The  returned value can be other than 'file_name(ob)' if
  * the function is defined by an inherited object.
  *
  * 0 is returned if the function was not defined.
+ *
+ * By default, functions that cannot be called from outside the object
+ * (protected and private functions) are treated as not defined. If 'flag'
+ * is specified and is nonzero, such functions are reported as well.
  *
  * Note that function_exists() does not check shadows.
  *
@@ -277,6 +282,8 @@ object
  *
  */
 varargs string function_exists( string str, object ob );
+
+varargs string function_exists( string str, object ob, int flag );
 
 /**
  * flush_messages - send all pending messages to a user

--- a/efuns/fluffos/zh-cn/system.zh-cn.h
+++ b/efuns/fluffos/zh-cn/system.zh-cn.h
@@ -242,19 +242,26 @@ mixed *function_profile( object ob );
  * function_exists()  -  查找对象中给定函数所在的文件
  * @param str 要检查的函数名称
  * @param ob 要检查的对象
+ * @param flag 如果为非零值，protected 和 private 类型的函数也会被报告
  * @returns 定义函数 'str' 的对象的文件名 'ob'。
  * 返回值可以与 'file_name(ob)' 不同，如果函数是由一个继
  * 承的对象定义的。
- * 
+ *
  * 如果函数未定义，则返回 0。
- * 
+ *
+ * 默认情况下，无法从对象外部呼叫的函数（protected 和 private
+ * 类型）会被视为未定义。如果指定参数 'flag' 且为非零值，
+ * 这些函数也会被报告。
+ *
  * 请注意，function_exists() 不检查阴影。
- * 
+ *
  * 如果没有对象作为第二个参数传入，则此 efun 将默认为
  * this_object()。
  *
  */
 varargs string function_exists( string str, object ob );
+
+varargs string function_exists( string str, object ob, int flag );
 
 /**
  * flush_messages - 发送所有待处理的消息给用户


### PR DESCRIPTION
FluffOS's `function_exists()` accepts an optional third `flag` argument — when nonzero, protected and private functions are reported as well. The FluffOS stub headers only declare the two-argument form, so a legitimate call like `function_exists(name, ob, 1)` produces a spurious argument-count diagnostic.

This adds the three-argument overload to `efuns/fluffos/system.h` and `efuns/fluffos/zh-cn/system.zh-cn.h` (following the multi-declaration pattern already used in `efuns/ldmud/efun.h`) and documents the flag in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)