### PR TITLE
Fix array typing bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Refactored preparser and macro expansion for speed and better reliability
 - Fix: spurious "Cannot find name" on FluffOS closure-variable calls
 - Fix: closure-variable calls now resolve to the correct function signature and return type
-- Improve array type checking and array efun signatures
+- Fix: Incorrect array result types and efun signatures
 
 ## 1.1.49
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Refactored preparser and macro expansion for speed and better reliability
 - Fix: spurious "Cannot find name" on FluffOS closure-variable calls
 - Fix: closure-variable calls now resolve to the correct function signature and return type
+- Improve array type checking and array efun signatures
 
 ## 1.1.49
 

--- a/efuns/fluffos/arrays.h
+++ b/efuns/fluffos/arrays.h
@@ -1,9 +1,5 @@
 // arrays.h
 
-#undef ALL_ARRAY_TYPES
-#define ALL_ARRAY_TYPES string*|int*|float*|object*|mixed*|function*
-#undef ALL_PRIMITIVE_TYPES
-#define ALL_PRIMITIVE_TYPES string|int|float|object|mixed|function
 
 /**
  * unique_array() - partitions an array of objects into groups
@@ -19,17 +15,19 @@
  *
  * @template {object} T
  * @param {T*} obarr The array of objects to partition
- * @param separator The function to use to partition the array
+ * @param {string} separator The name of the function in each object to partition by
  * @param {T} skip The value to skip
  * @returns {<T*>*} The partitioned array
  */
 varargs mixed unique_array(object *obarr, string separator, mixed skip);
 
 /**
- * @template T, Y
+ * @template T
  * @callback uniqueArrayCallback
- * @param {T} element The element to test
- * @returns {Y} The map callback return value
+ * @param {T} element The element to group
+ * @returns {mixed} The value to group by -- elements returning equal values are
+ *                  grouped together. Its type does not affect the result type, so
+ *                  unlike mapArrayCallback there is nothing to parameterise here.
  */
 
 
@@ -47,7 +45,7 @@ varargs mixed unique_array(object *obarr, string separator, mixed skip);
  *
  * @template T
  * @param {T*} arr The array of objects to partition
- * @param {uniqueArrayCallback<T,Y>} f The function to use to partition the array
+ * @param {uniqueArrayCallback<T>} f The function to use to partition the array
  * @param {T|void} skip The value to skip
  * @returns {<T*>*} The partitioned array
  */

--- a/efuns/fluffos/arrays.h
+++ b/efuns/fluffos/arrays.h
@@ -76,21 +76,38 @@ varargs <mixed*>* unique_array(mixed *arr, function f, mixed skip );
  * that the array must be homogeneous, composed entirely of a single type,
  * where  that type is string, int, or float.  Arrays of arrays are sorted
  * by sorting based on the first element, making database sorts possible.
- * @template {ALL_ARRAY_TYPES} T
- * @param {T} arr The array to sort
- * @returns {T} The sorted array
+ * @template T
+ * @param {T*} arr The array to sort
+ * @returns {T*} The sorted array
  */
 mixed *sort_array( mixed *arr, string fun, object ob, mixed extra... );
+
+/**
+ * sort_array() - sort an array using a function pointer to compare elements.
+ *
+ * @template T
+ * @param {T*} arr The array to sort
+ * @returns {T*} The sorted array
+ */
 mixed *sort_array( mixed *arr, function f, mixed extra... );
+
+/**
+ * sort_array() - sort an array using the built-in sort routines. A 'direction'
+ * of 1 or 0 sorts in ascending order, -1 in descending order.
+ *
+ * @template T
+ * @param {T*} arr The array to sort
+ * @returns {T*} The sorted array
+ */
 mixed *sort_array( mixed *arr, int direction );
 
 /**
  * shuffle() - Rearrange the elements in the array in random order
  *
  * Shuffle the array and return.
- * @template {ALL_ARRAY_TYPES} T
- * @param {T} arr The array to shuffle
- * @returns {T} The shuffled array
+ * @template T
+ * @param {T*} arr The array to shuffle
+ * @returns {T*} The shuffled array
  */
 mixed *shuffle(mixed *arr);
 
@@ -153,6 +170,27 @@ varargs int member_array( mixed item, mixed * | string arr, void | int start );
  *
  */
 mixed *map_array( mixed *arr, string fun, object ob, mixed extra... );
+
+/**
+ * @template T, Y
+ * @callback mapArrayCallback
+ * @param {T} element The element being mapped
+ * @returns {Y} The replacement for that element
+ */
+
+/**
+ * map_array() - modify an array of elements via application of a function pointer.
+ *
+ * The result holds whatever 'f' returns, so mapping a `string*` through a callback
+ * returning an int yields an `int*`. The `ob->fun()` form above cannot be typed this
+ * way -- the function is named by a string, so its return type is not knowable -- and
+ * stays `mixed*`.
+ *
+ * @template T, Y
+ * @param {T*} arr The array to map
+ * @param {mapArrayCallback<T,Y>} f The function applied to each element
+ * @returns {Y*} The mapped array
+ */
 mixed *map_array( mixed *arr, function f, mixed extra... );
 
 /**
@@ -169,6 +207,20 @@ mixed *map_array( mixed *arr, function f, mixed extra... );
  *
  */
 mixed *filter_array( mixed *arr, string fun, object|string ob, mixed extra... );
+
+/**
+ * filter_array() - return a selective sub-array using a function pointer.
+ *
+ * Unlike map_array(), filtering selects elements rather than transforming them, so the
+ * result holds the same element type as the input -- the callback's return value is only
+ * the keep-or-discard test. The `ob->fun()` form above cannot be typed this way and stays
+ * `mixed*`.
+ *
+ * @template T
+ * @param {T*} arr The array to filter
+ * @param {filterCallback<T>} f Nonzero to keep the element, zero to discard it
+ * @returns {T*} The elements that passed the test
+ */
 mixed *filter_array( mixed *arr, function f, mixed extra... );
 
 /**

--- a/efuns/fluffos/zh-cn/arrays.zh-cn.h
+++ b/efuns/fluffos/zh-cn/arrays.zh-cn.h
@@ -38,21 +38,38 @@ mixed unique_array( mixed *arr, function f, void | mixed skip );
  * 完全由单一类型组成，其中该类型可以是string、int或float。
  * 数组中的数组通过基于第一个元素进行排序，从而使数据库
  * 排序成为可能。
- * @template {ALL_ARRAY_TYPES} T
- * @param {T} arr 要排序的数组
- * @returns {T} 排序后的数组
+ * @template T
+ * @param {T*} arr 要排序的数组
+ * @returns {T*} 排序后的数组
  */
 mixed *sort_array( mixed *arr, string fun, object ob );
+
+/**
+ * sort_array() - 使用函数指针比较元素来对数组进行排序。
+ *
+ * @template T
+ * @param {T*} arr 要排序的数组
+ * @returns {T*} 排序后的数组
+ */
 mixed *sort_array( mixed *arr, function f );
+
+/**
+ * sort_array() - 使用内置排序routine对数组进行排序。'direction'
+ * 为1或0时按升序排序，为-1时按降序排序。
+ *
+ * @template T
+ * @param {T*} arr 要排序的数组
+ * @returns {T*} 排序后的数组
+ */
 mixed *sort_array( mixed *arr, int direction );
 
 /**
  * shuffle() - 将数组中的元素随机排列
  *
  * 随机打乱数组并返回。
- * @template {ALL_ARRAY_TYPES} T
- * @param {T} arr 要打乱的数组
- * @returns {T} 打乱后的数组
+ * @template T
+ * @param {T*} arr 要打乱的数组
+ * @returns {T*} 打乱后的数组
  */
 mixed *shuffle(mixed *arr);
 
@@ -114,6 +131,26 @@ varargs int member_array( mixed item, mixed * | string arr, void | int start );
  *
  */
 mixed *map_array( mixed *arr, string fun, object ob, mixed extra... );
+
+/**
+ * @template T, Y
+ * @callback mapArrayCallback
+ * @param {T} element 被映射的元素
+ * @returns {Y} 该元素的替换值
+ */
+
+/**
+ * map_array() - 通过应用函数指针修改元素数组。
+ *
+ * 结果持有'f'返回的内容，因此将 `string*` 通过返回int的回调
+ * 映射后得到 `int*`。上面的 `ob->fun()` 形式无法这样标注类型
+ * ——函数由字符串命名，其返回类型不可知——因此保持 `mixed*`。
+ *
+ * @template T, Y
+ * @param {T*} arr 要映射的数组
+ * @param {mapArrayCallback<T,Y>} f 应用于每个元素的函数
+ * @returns {Y*} 映射后的数组
+ */
 mixed *map_array( mixed *arr, function f, mixed extra... );
 
 /**
@@ -130,6 +167,19 @@ mixed *map_array( mixed *arr, function f, mixed extra... );
  *
  */
 mixed *filter_array( mixed *arr, string fun, object|string ob, mixed extra... );
+
+/**
+ * filter_array() - 使用函数指针返回选择性的子数组。
+ *
+ * 与 map_array() 不同，过滤是选择元素而非转换元素，因此结果的
+ * 元素类型与输入相同——回调的返回值只是保留或丢弃的判断。
+ * 上面的 `ob->fun()` 形式无法这样标注类型，因此保持 `mixed*`。
+ *
+ * @template T
+ * @param {T*} arr 要过滤的数组
+ * @param {filterCallback<T>} f 非零表示保留该元素，零表示丢弃
+ * @returns {T*} 通过测试的元素
+ */
 mixed *filter_array( mixed *arr, function f, mixed extra... );
 
 /**

--- a/efuns/fluffos/zh-cn/arrays.zh-cn.h
+++ b/efuns/fluffos/zh-cn/arrays.zh-cn.h
@@ -1,10 +1,5 @@
 // arrays.h
 
-#undef ALL_ARRAY_TYPES
-#define ALL_ARRAY_TYPES string*|int*|float*|object*|mixed*|function*
-#undef ALL_PRIMITIVE_TYPES
-#define ALL_PRIMITIVE_TYPES string|int|float|object|mixed|function
-
 
 /**
  * unique_array() - 将对象数组分区为组
@@ -16,9 +11,35 @@
  * 不同，数组的每个元素将被传递给f，并根据f的返回值进行分区。
  * 特别是，数组不需要由对象组成。
  *
+ * @template {object} T
+ * @param {T*} obarr 要分区的对象数组
+ * @param {string} separator 每个对象中用于分区的函数名
+ * @param {T} skip 要跳过的值
+ * @returns {<T*>*} 分区后的数组
  */
 mixed unique_array( object *obarr, string separator, void | mixed skip);
-mixed unique_array( mixed *arr, function f, void | mixed skip );
+
+/**
+ * @template T
+ * @callback uniqueArrayCallback
+ * @param {T} element 要分组的元素
+ * @returns {mixed} 用于分组的值——返回相同值的元素会被分到一组。
+ *                  它的类型不影响结果类型，因此与 mapArrayCallback
+ *                  不同，这里没有需要参数化的类型。
+ */
+
+/**
+ * unique_array() - 使用函数指针将数组分区为组。
+ *
+ * 数组的每个元素将被传递给f，并根据f的返回值进行分区。
+ *
+ * @template T
+ * @param {T*} arr 要分区的数组
+ * @param {uniqueArrayCallback<T>} f 用于分区的函数
+ * @param {T|void} skip 要跳过的值
+ * @returns {<T*>*} 分区后的数组
+ */
+<mixed*>* unique_array( mixed *arr, function f, void | mixed skip );
 
 /**
  * sort_array() - 对数组进行排序

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -30754,6 +30754,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // see https://github.com/jlchmura/lpc-language-server/issues/190
                     (isArrayType(declaredType) && declaredType.resolvedTypeArguments && !isAnonymousObjectType(first(declaredType.resolvedTypeArguments)))
                 ) {
+                    // Whether the declaration states what the array holds. `mixed*` does not
+                    // count: `mixed` is `any`, which says nothing about the contents.
+                    const declaresElementType = isArrayType(declaredType) && !isTypeAny(declaredType.resolvedTypeArguments?.[0] ?? anyType);
+
                     if (isEmptyArrayAssignment(node)) {
                         // An evolving array starts empty and takes its element type from what
                         // later gets assigned into it -- right for `mixed *x = ({})`, where the
@@ -30761,13 +30765,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // what the array holds, and evolving from that discarded the declared
                         // element type: the variable drifted to `mixed*` and `x += ({ 123 })`
                         // stopped being an error.
-                        const declaredElementType = isArrayType(declaredType) ? declaredType.resolvedTypeArguments?.[0] : undefined;
-                        if (declaredElementType && !isTypeAny(declaredElementType)) {
-                            return declaredType;
-                        }
-                        return getEvolvingArrayType(neverType);
+                        return declaresElementType ? declaredType : getEvolvingArrayType(neverType);
                     }
                     const assignedType = getWidenedLiteralType(getInitialOrAssignedType(flow));
+                    // Narrowing may only make a type more specific. An efun returning `mixed*`
+                    // passes the assignability check below -- `mixed` is `any` -- but adopting it
+                    // would widen the reference past its own declaration, so `int *r = sort_array(...)`
+                    // would report `r` as `mixed*` from then on. Keep what the author declared.
+                    if (declaresElementType && isArrayType(assignedType) && isTypeAny(assignedType.resolvedTypeArguments?.[0] ?? anyType)) {
+                        return declaredType;
+                    }
                     return isTypeAssignableTo(assignedType, declaredType) ? assignedType : anyArrayType;
                 }
                 const t = isInCompoundLikeAssignment(node) ? getBaseTypeOfLiteralType(declaredType) : declaredType;

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -16679,10 +16679,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 else if (isArrayType(leftType) && isArrayType(rightType)) {
                     // LPC allows array addition and subtraction
                     const leftElementType = first(leftType.resolvedTypeArguments);
-                    const rightElementType = first(rightType.resolvedTypeArguments);               
-                    if (areTypesComparable(leftElementType, rightElementType)) {
+                    const rightElementType = first(rightType.resolvedTypeArguments);
+                    // Assignability, not comparability. The result keeps the left array's
+                    // element type, so every element coming from the right has to fit it --
+                    // and comparability succeeds when merely *some* union constituent matches,
+                    // which let `string* += ({ "f", 123 })` through: the right element type is
+                    // `string | int`, and its `string` half was enough to satisfy the check.
+                    if (isTypeAssignableTo(rightElementType, leftElementType)) {
                         resultType = leftType;
-                    }                                        
+                    }
                 } 
                 else if (isMappingType(leftType) && isMappingType(rightType)) {
                     resultType = leftType;
@@ -30750,6 +30755,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     (isArrayType(declaredType) && declaredType.resolvedTypeArguments && !isAnonymousObjectType(first(declaredType.resolvedTypeArguments)))
                 ) {
                     if (isEmptyArrayAssignment(node)) {
+                        // An evolving array starts empty and takes its element type from what
+                        // later gets assigned into it -- right for `mixed *x = ({})`, where the
+                        // element type is genuinely open. But `string *x = ({})` already states
+                        // what the array holds, and evolving from that discarded the declared
+                        // element type: the variable drifted to `mixed*` and `x += ({ 123 })`
+                        // stopped being an error.
+                        const declaredElementType = isArrayType(declaredType) ? declaredType.resolvedTypeArguments?.[0] : undefined;
+                        if (declaredElementType && !isTypeAny(declaredElementType)) {
+                            return declaredType;
+                        }
                         return getEvolvingArrayType(neverType);
                     }
                     const assignedType = getWidenedLiteralType(getInitialOrAssignedType(flow));

--- a/server/src/compiler/utilities.ts
+++ b/server/src/compiler/utilities.ts
@@ -2541,10 +2541,19 @@ export function getFunctionFlags(node: SignatureDeclaration | undefined) {
  *
  * @internal
  */
-export function getEffectiveReturnTypeNode(node: SignatureDeclaration | JSDocSignature): TypeNode | undefined {    
-    return isJSDocSignature(node) ?
-        node.type && node.type.typeExpression && node.type.typeExpression.type :        
-        (isInJSFile(node) ? getJSDocReturnType(node) : undefined) ?? node.type;
+export function getEffectiveReturnTypeNode(node: SignatureDeclaration | JSDocSignature): TypeNode | undefined {
+    if (isJSDocSignature(node)) {
+        return node.type && node.type.typeExpression && node.type.typeExpression.type;
+    }
+    const docType = isInJSFile(node) ? getJSDocReturnType(node) : undefined;
+    // `@returns` narrows the element the same way `@param` and `@type` do, so a `*` on the
+    // declared return type has to survive it -- `mixed *f()` with `@returns {T}` returns `T*`.
+    // Without this the two halves of one signature disagreed: the parameter kept its array rank
+    // and the return type quietly lost it, so a generic efun handed back its element type.
+    if (docType && node.type && shouldJsDocTypeOverrideTypeNode(node.type)) {
+        return preserveDeclaredArrayRank(node.type, docType);
+    }
+    return docType ?? node.type;
 }
 
 /** @internal */
@@ -3305,20 +3314,7 @@ export function getEffectiveTypeAnnotationNode(node: Node, originatingFile?: Sou
         // narrows the element (e.g. `@type {STD_NPC}`), preserve the declarator's array
         // rank by wrapping the JSDoc type in an array. Without this, the `*` is dropped and
         // `mobs` is treated as a single object instead of an array (see #317).
-        if (possibleType !== type && isArrayTypeNode(type) && !isArrayTypeNode(possibleType)) {
-            const overrideHost = type as TypeNode & { jsDocArrayTypeOverride?: ArrayTypeNode };
-            const cached = overrideHost.jsDocArrayTypeOverride;
-            if (cached && cached.elementType === possibleType) {
-                possibleType = cached;
-            }
-            else {
-                const wrapped = factory.createArrayTypeNode(possibleType);
-                setParent(wrapped, type.parent);
-                setTextRangePosEnd(wrapped, type.pos, type.end);
-                overrideHost.jsDocArrayTypeOverride = wrapped;
-                possibleType = wrapped;
-            }
-        }
+        possibleType = preserveDeclaredArrayRank(type, possibleType);
         if (isVariableDeclaration(node) && isIdentifier(node.name) && shouldJsDocTypeOverrideTypeNode(possibleType)) {
             // for a variable with a jsdoc overridable type, look to see if there is a @var tag            
             // we can't use the node's file, because that may be different. the @var tag will be in the file
@@ -3344,6 +3340,30 @@ export function getEffectiveTypeAnnotationNode(node: Node, originatingFile?: Sou
     }
 
     return tryGetJsDocType();
+}
+
+/**
+ * An LPC declarator carries its own array rank -- `object *mobs`, `mixed *sort_array(...)` --
+ * while a doc type often narrows only the element: `@type {STD_NPC}`, `@returns {T}`. Re-apply
+ * the declarator's array so the `*` is not dropped (see #317).
+ *
+ * The wrapped node is cached on the declared type node, so repeated calls hand back the same
+ * node rather than a fresh one each time.
+ */
+function preserveDeclaredArrayRank(declaredType: TypeNode, docType: TypeNode): TypeNode {
+    if (docType === declaredType || !isArrayTypeNode(declaredType) || isArrayTypeNode(docType)) {
+        return docType;
+    }
+    const overrideHost = declaredType as TypeNode & { jsDocArrayTypeOverride?: ArrayTypeNode; };
+    const cached = overrideHost.jsDocArrayTypeOverride;
+    if (cached && cached.elementType === docType) {
+        return cached;
+    }
+    const wrapped = factory.createArrayTypeNode(docType);
+    setParent(wrapped, declaredType.parent);
+    setTextRangePosEnd(wrapped, declaredType.pos, declaredType.end);
+    overrideHost.jsDocArrayTypeOverride = wrapped;
+    return wrapped;
 }
 
 function shouldJsDocTypeOverrideTypeNode(type: TypeNode): boolean {

--- a/server/src/tests/arrayConcatElementTypes.spec.ts
+++ b/server/src/tests/arrayConcatElementTypes.spec.ts
@@ -1,0 +1,71 @@
+import * as lpc from "./_namespaces/lpc.js";
+import { createTestLanguageService } from "./harness.js";
+
+/**
+ * Appending to an array checked the element types with `areTypesComparable`, which succeeds when
+ * merely *some* union constituent matches. So a mixed literal slipped through:
+ *
+ *     string *items;
+ *     items += ({ "f", 123, 567 });   // right element type is `string | int`
+ *
+ * The `string` half satisfied comparability and no error was reported, while the homogeneous
+ * `items += ({ 123 })` was caught -- `int` alone is not comparable to `string`.
+ *
+ * The result keeps the left array's element type, so every element arriving from the right has
+ * to fit it. That is assignability, and it is directional.
+ *
+ * Subtraction is deliberately left permissive: `-` removes elements rather than adding them, so
+ * the right side's element type does not have to fit. Taking ints out of a `string*` is a no-op,
+ * not a mistake.
+ */
+function diagnosticsFor(source: string): string[] {
+    const { ls, abs } = createTestLanguageService({ "test.c": source }, {
+        driverType: lpc.LanguageVariant.FluffOS,
+        diagnostics: true,
+    });
+    return ls.getSemanticDiagnostics(abs("test.c"))
+        .map(d => `${d.code}: ${lpc.flattenDiagnosticMessageText(d.messageText, " ")}`);
+}
+
+describe("appending an array with a union element type", () => {
+    it("reports a literal that mixes a valid element type with an invalid one", () => {
+        expect(diagnosticsFor(`test() { string *a; a += ({ "f", 123, 567 }); }`))
+            .toEqual(["2365: Operator '+=' cannot be applied to types 'string*' and '(string | int)*'."]);
+    });
+
+    it("reports it the same way after an empty array initializer", () => {
+        // The two fixes meet here: the declaration keeps its `string*` type, and the append is
+        // then checked against it.
+        expect(diagnosticsFor(`test() { string *a = ({}); a += ({ "f", 123, 567 }); }`))
+            .toEqual(["2365: Operator '+=' cannot be applied to types 'string*' and '(string | int)*'."]);
+    });
+
+    it("still accepts a literal whose elements all fit", () => {
+        expect(diagnosticsFor(`test() { string *a; a += ({ "f", "g" }); }`)).toEqual([]);
+    });
+
+    it("still reports a homogeneous literal of the wrong type", () => {
+        expect(diagnosticsFor(`test() { string *a; a += ({ 1, 2 }); }`))
+            .toEqual(["2365: Operator '+=' cannot be applied to types 'string*' and 'int*'."]);
+    });
+});
+
+describe("appending where one side says nothing about its contents", () => {
+    it("accepts anything appended to a mixed array", () => {
+        expect(diagnosticsFor(`test() { mixed *a; a += ({ "f", 123 }); }`)).toEqual([]);
+    });
+
+    it("accepts a mixed array appended to a typed one", () => {
+        // `mixed` is permissive in both directions here, as it is everywhere else.
+        expect(diagnosticsFor(`test() { string *a; mixed *b; a += b; }`)).toEqual([]);
+        expect(diagnosticsFor(`test() { mixed *a; string *b; a += b; }`)).toEqual([]);
+    });
+});
+
+describe("array subtraction stays permissive", () => {
+    it("does not report removing elements the array could not contain", () => {
+        // `-` takes elements out; nothing new arrives, so the element types need not match.
+        expect(diagnosticsFor(`test() { string *a; a -= ({ "f", 123 }); }`)).toEqual([]);
+        expect(diagnosticsFor(`test() { string *a; int *b; a -= b; }`)).toEqual([]);
+    });
+});

--- a/server/src/tests/arrayDeclaredTypeRetention.spec.ts
+++ b/server/src/tests/arrayDeclaredTypeRetention.spec.ts
@@ -123,3 +123,33 @@ describe("filter_array keeps the input element type", () => {
         expect(diagnosticsFor(`test() {\n  string *items = ({ "abc" });\n  int *r = filter_array(items, "f", this_object());\n}\n`)).toEqual([]);
     });
 });
+
+describe("unique_array partitions into an array of arrays of the input element type", () => {
+    // Its callback tag referenced `uniqueArrayCallback<T,Y>` while only `T` was declared. `Y`
+    // is never used in the result -- unique_array groups by whatever the callback returns, and
+    // that value's type does not reach the return type -- so the callback is now single-
+    // parameter rather than declaring a type argument nothing consumes.
+    it("returns the input element type nested one level deeper", () => {
+        expect(diagnosticsFor(`test() {\n  string *s = ({ "a" });\n  string **g = unique_array(s, (: $1 :));\n}\n`)).toEqual([]);
+    });
+
+    it("reports a wrong element type", () => {
+        expect(diagnosticsFor(`test() {\n  string *s = ({ "a" });\n  int **g = unique_array(s, (: $1 :));\n}\n`).join(" "))
+            .toContain("2322:");
+    });
+
+    it("reports a result that is not nested", () => {
+        expect(diagnosticsFor(`test() {\n  string *s = ({ "a" });\n  string *g = unique_array(s, (: $1 :));\n}\n`).join(" "))
+            .toContain("2322:");
+    });
+
+    it("contextually types the closure's $1 as the array's element type", () => {
+        expect(hoverAt(`test() {\n  string *s = ({ "a" });\n  string **g = unique_array(s, (: $1 :));\n}\n`, "$1 :)")).toBe("string");
+    });
+
+    it("types the ob->separator() form too", () => {
+        expect(diagnosticsFor(`test() {\n  object *o = ({});\n  object **g = unique_array(o, "sep", 0);\n}\n`)).toEqual([]);
+        expect(diagnosticsFor(`test() {\n  object *o = ({});\n  int **g = unique_array(o, "sep", 0);\n}\n`).join(" "))
+            .toContain("2322:");
+    });
+});

--- a/server/src/tests/arrayDeclaredTypeRetention.spec.ts
+++ b/server/src/tests/arrayDeclaredTypeRetention.spec.ts
@@ -1,0 +1,125 @@
+import * as lpc from "./_namespaces/lpc.js";
+import { createTestLanguageService } from "./harness.js";
+
+/**
+ * An array variable kept whatever array type was assigned into it, even when that type was
+ * *wider* than its own declaration:
+ *
+ *     int *result = sort_array(items, 1);   // sort_array returned mixed*
+ *     result;                               // reported as mixed*
+ *
+ * Narrowing is supposed to make a type more specific -- that branch exists so that assigning a
+ * narrower array type to a declared array narrows the reference (lpc-language-server#190). A
+ * `mixed*` passes the assignability check because `mixed` is `any`, so it was adopted too, and
+ * the variable widened past its own declaration from that point on.
+ *
+ * Scalars never had this problem: `int r = some_mixed()` stays `int`.
+ */
+function build(source: string) {
+    const { ls, abs } = createTestLanguageService({ "test.c": source }, {
+        driverType: lpc.LanguageVariant.FluffOS,
+        diagnostics: true,
+    });
+    return { ls, file: abs("test.c") };
+}
+
+function hoverAt(source: string, marker: string): string | undefined {
+    const { ls, file } = build(source);
+    return ls.getQuickInfoAtPosition(file, source.indexOf(marker))
+        ?.displayParts?.map(p => p.text).join("").replace(/\s+/g, " ").trim();
+}
+
+function diagnosticsFor(source: string): string[] {
+    const { ls, file } = build(source);
+    return ls.getSemanticDiagnostics(file).map(d => `${d.code}: ${lpc.flattenDiagnosticMessageText(d.messageText, " ")}`);
+}
+
+describe("an array variable assigned a wider array type", () => {
+    it("keeps its declared type rather than widening to mixed*", () => {
+        const source = `mixed *g() { return ({}); }\ntest() {\n  int *r = g();\n  r;\n}\n`;
+        expect(hoverAt(source, "r;\n}")).toBe("(local var) int* r");
+    });
+
+    it("behaves the same as the scalar case, which was always correct", () => {
+        const source = `mixed g() { return 1; }\ntest() {\n  int r = g();\n  r;\n}\n`;
+        expect(hoverAt(source, "r;\n}")).toBe("(local var) int r");
+    });
+
+    it("still narrows to a more specific assigned array type", () => {
+        // lpc-language-server#190 -- the reason this branch exists. Only widening changed.
+        const source = `test() {\n  object *w;\n  w = get_weaps();\n  w;\n}\nobject *get_weaps() { return ({ }); }\n`;
+        expect(hoverAt(source, "w;\n}")).toBe("(local var) object* w");
+    });
+});
+
+describe("sort_array and shuffle preserve their argument's element type", () => {
+    // Their LPCDoc used `@template {ALL_ARRAY_TYPES} T` with `@param {T}`, which does not infer.
+    // `@template T` with `@param {T*}` -- the form `filter` already used -- does. sort_array also
+    // has three overloads, and the annotation sat only on the first, so the `(arr, direction)`
+    // form callers reach most often was not generic at all.
+    it("reports assigning a sorted string array to an int array", () => {
+        for (const call of [`sort_array(items, 1)`, `sort_array(items, (: 1 :))`, `shuffle(items)`]) {
+            const source = `test() {\n  string *items = ({ "abc" });\n  int *r = ${call};\n}\n`;
+            expect(diagnosticsFor(source).join(" ")).toContain("2322: Type 'string*' is not assignable to type 'int*'.");
+        }
+    });
+
+    it("accepts the result at the element type it went in as", () => {
+        for (const call of [`sort_array(items, 1)`, `shuffle(items)`]) {
+            expect(diagnosticsFor(`test() {\n  string *items = ({ "abc" });\n  string *r = ${call};\n}\n`)).toEqual([]);
+        }
+        expect(diagnosticsFor(`test() {\n  int *items = ({ 1 });\n  int *r = sort_array(items, 1);\n}\n`)).toEqual([]);
+    });
+});
+
+describe("map_array takes its element type from the callback's return type", () => {
+    // The `function f` overload had no @template at all, so it always returned `mixed*`. It now
+    // uses the same @callback pattern `map()`'s array overload already used.
+    it("reports a callback returning int assigned to a string array", () => {
+        expect(diagnosticsFor(`test() {\n  string *items = ({ "abc" });\n  string *lens = map_array(items, (: strlen($1) :));\n}\n`).join(" "))
+            .toContain("2322: Type 'int*' is not assignable to type 'string*'.");
+    });
+
+    it("accepts the array type the callback actually produces", () => {
+        expect(diagnosticsFor(`test() {\n  string *items = ({ "abc" });\n  int *lens = map_array(items, (: strlen($1) :));\n}\n`)).toEqual([]);
+        expect(diagnosticsFor(`test() {\n  string *items = ({ "abc" });\n  string *up = map_array(items, (: upper_case($1) :));\n}\n`)).toEqual([]);
+    });
+
+    it("contextually types the closure's $1 as the array's element type", () => {
+        const source = `test() {\n  string *items = ({ "abc" });\n  int *lens = map_array(items, (: $1 :));\n}\n`;
+        expect(hoverAt(source, "$1 :)")).toBe("string");
+    });
+
+    it("leaves the ob->fun() overload as mixed*", () => {
+        // The function is named by a string, so its return type is not knowable.
+        expect(diagnosticsFor(`test() {\n  string *items = ({ "abc" });\n  int *r = map_array(items, "cmp", this_object());\n}\n`)).toEqual([]);
+    });
+
+    it("matches map(), which was already annotated this way", () => {
+        expect(diagnosticsFor(`test() {\n  string *items = ({ "abc" });\n  string *lens = map(items, (: strlen($1) :));\n}\n`).join(" "))
+            .toContain("2322: Type 'int*' is not assignable to type 'string*'.");
+    });
+});
+
+describe("filter_array keeps the input element type", () => {
+    // Filtering selects rather than transforms, so unlike map_array the result element type is
+    // the input's -- the callback's return value is only the keep-or-discard test. This mirrors
+    // how `filter` in general.h was already annotated.
+    it("reports a filtered string array assigned to an int array", () => {
+        expect(diagnosticsFor(`test() {\n  string *items = ({ "abc" });\n  int *r = filter_array(items, (: strlen($1) > 2 :));\n}\n`).join(" "))
+            .toContain("2322: Type 'string*' is not assignable to type 'int*'.");
+    });
+
+    it("accepts the result at the element type it went in as", () => {
+        expect(diagnosticsFor(`test() {\n  string *items = ({ "abc" });\n  string *r = filter_array(items, (: strlen($1) > 2 :));\n}\n`)).toEqual([]);
+        expect(diagnosticsFor(`test() {\n  int *n = ({ 1 });\n  int *r = filter_array(n, (: $1 > 0 :));\n}\n`)).toEqual([]);
+    });
+
+    it("contextually types the closure's $1 as the array's element type", () => {
+        expect(hoverAt(`test() {\n  string *items = ({ "abc" });\n  string *r = filter_array(items, (: $1 :));\n}\n`, "$1 :)")).toBe("string");
+    });
+
+    it("leaves the ob->fun() overload as mixed*", () => {
+        expect(diagnosticsFor(`test() {\n  string *items = ({ "abc" });\n  int *r = filter_array(items, "f", this_object());\n}\n`)).toEqual([]);
+    });
+});

--- a/server/src/tests/emptyArrayInitializer.spec.ts
+++ b/server/src/tests/emptyArrayInitializer.spec.ts
@@ -1,0 +1,88 @@
+import * as lpc from "./_namespaces/lpc.js";
+import { createTestLanguageService } from "./harness.js";
+
+/**
+ * `string *items = ({});` used to lose its declared element type.
+ *
+ * An empty array initializer starts the variable off as an *evolving* array -- one that takes
+ * its element type from whatever is assigned into it later. That is right for `mixed *x = ({})`,
+ * where the element type is genuinely open, but `string *x = ({})` has already said what the
+ * array holds. Evolving from there let the variable drift to `mixed*`, so `x += ({ 123 })`
+ * silently type-checked.
+ *
+ * Only the compound-assignment path was affected: a plain `x = ({ 123 })` is checked against the
+ * declared type and always reported. That is why this survived -- the obvious test passes.
+ */
+function build(source: string) {
+    const { ls, abs } = createTestLanguageService({ "test.c": source }, {
+        driverType: lpc.LanguageVariant.FluffOS,
+        diagnostics: true,
+    });
+    return { ls, file: abs("test.c") };
+}
+
+function diagnosticsFor(source: string): string[] {
+    const { ls, file } = build(source);
+    return ls.getSemanticDiagnostics(file).map(d => `${d.code}: ${lpc.flattenDiagnosticMessageText(d.messageText, " ")}`);
+}
+
+function hoverAt(source: string, marker: string): string | undefined {
+    const { ls, file } = build(source);
+    // The kind prefix emits its own padding; collapse it so these read as what the editor shows.
+    return ls.getQuickInfoAtPosition(file, source.indexOf(marker))
+        ?.displayParts?.map(p => p.text).join("").replace(/\s+/g, " ").trim();
+}
+
+describe("an array declared with an empty array initializer", () => {
+    it("keeps its declared element type", () => {
+        expect(hoverAt(`test() {\n    string *items = ({});\n    items;\n}\n`, "items;")).toBe("(local var) string* items");
+    });
+
+    it("reports appending the wrong element type", () => {
+        expect(diagnosticsFor(`test() {\n    string *items = ({});\n    items += ({ 123 });\n}\n`))
+            .toEqual(["2365: Operator '+=' cannot be applied to types 'string*' and 'int*'."]);
+    });
+
+    it("accepts appending the right element type", () => {
+        expect(diagnosticsFor(`test() {\n    string *items = ({});\n    items += ({ "a" });\n}\n`)).toEqual([]);
+    });
+
+    it("applies to any declared element type, not just string", () => {
+        expect(diagnosticsFor(`test() {\n    int *n = ({});\n    n += ({ "a" });\n}\n`))
+            .toEqual(["2365: Operator '+=' cannot be applied to types 'int*' and 'string*'."]);
+        expect(diagnosticsFor(`test() {\n    object *o = ({});\n    o += ({ 1 });\n}\n`))
+            .toEqual(["2365: Operator '+=' cannot be applied to types 'object*' and 'int*'."]);
+    });
+
+    it("matches how the same declaration behaves without the empty initializer", () => {
+        // These two always worked; they are here so the three forms cannot drift apart again.
+        const expected = ["2365: Operator '+=' cannot be applied to types 'string*' and 'int*'."];
+        expect(diagnosticsFor(`test() {\n    string *items;\n    items += ({ 123 });\n}\n`)).toEqual(expected);
+        expect(diagnosticsFor(`test() {\n    string *items = ({ "a" });\n    items += ({ 123 });\n}\n`)).toEqual(expected);
+    });
+
+    it("still reports a direct assignment of the wrong array type", () => {
+        expect(diagnosticsFor(`test() {\n    string *items = ({});\n    items = ({ 123 });\n}\n`).join(" "))
+            .toContain("2322: Type 'int*' is not assignable to type 'string*'.");
+    });
+
+    it("iterates as the declared element type", () => {
+        expect(hoverAt(`test() {\n    string *s = ({});\n    foreach(string x in s) { x; }\n}\n`, "x in s")).toBe("(local var) string x");
+    });
+});
+
+describe("arrays whose element type is genuinely open still evolve", () => {
+    it("leaves mixed* alone", () => {
+        // `mixed` says nothing about the contents, so the evolving-array path still applies and
+        // appending is not an error.
+        expect(diagnosticsFor(`test() {\n    mixed *m = ({});\n    m += ({ 123 });\n}\n`)).toEqual([]);
+    });
+
+    it("still narrows an array variable to a more specific assigned type", () => {
+        // lpc-language-server#190: the branch this fix sits inside exists so that assigning a
+        // narrower array type to a declared array narrows the reference. Only the empty-literal
+        // short circuit changed; this must keep working.
+        const source = `test() {\n    object *w;\n    w = get_weaps();\n    w;\n}\nobject *get_weaps() { return ({ }); }\n`;
+        expect(hoverAt(source, "w;\n}")).toBe("(local var) object* w");
+    });
+});


### PR DESCRIPTION
## Summary

Five bugs that all showed up as "my typed array isn't actually typed". An array variable now keeps the element type it was declared with, appending to it is checked against that type, and the array efuns relate their result type to what was passed in.

```lpc
string *items = ({});
items += ({ 123 });                                  // 2365  'string*' and 'int*'
items += ({ "f", 123, 567 });                        // 2365  'string*' and '(string | int)*'

int *result = sort_array(items, 1);                  // 2322  'string*' is not assignable to 'int*'
string *lens = map_array(items, (: strlen($1) :));   // 2322  'int*' is not assignable to 'string*'
int *kept = filter_array(items, (: strlen($1) > 2 :)); // 2322  'string*' is not assignable to 'int*'
```

Every one of those was accepted silently before.

## 1. An empty array initializer discarded the declared element type

`string *items = ({})` started the variable as an *evolving* array — one that takes its element type from whatever gets assigned into it later. That is right for `mixed *x = ({})`, where the element type is genuinely open, but `string *x = ({})` has already said what the array holds. Evolving from there dropped the declared element type, the variable drifted to `mixed*`, and appending anything at all type-checked.

An empty initializer now yields the declared array type whenever the declaration states an element type.

Only the **compound** path was affected, which is why this survived: `items = ({ 123 })` is checked against the declared type and was always reported. The obvious test passes.

## 2. Appending checked element types with comparability instead of assignability

```lpc
string *items;
items += ({ "f", 123, 567 });   // right element type is `string | int`
```

`areTypesComparable` succeeds when merely *some* union constituent matches, and the `string` half was enough. The homogeneous `items += ({ 123 })` was caught only because `int` alone is not comparable to `string`.

The result keeps the left array's element type, so every element arriving from the right has to fit it — that is assignability, which is directional and requires every constituent to fit.

This is **independent of #1**: it reproduces with a plain `string *items;` and no initializer. The originally reported case was hitting both at once.

Subtraction is deliberately left permissive. `-` removes elements rather than adding them, so the right side's element type does not have to fit; taking ints out of a `string*` is a no-op, not a mistake. There is a test pinning that so it doesn't get "fixed" by someone pattern-matching on the `+` change.

## 3. Array variables widened past their own declaration

```lpc
int *result = sort_array(items, 1);   // sort_array returned mixed*
result;                               // reported as mixed* from here on
```

Narrowing is supposed to make a type *more specific* — that branch exists so assigning a narrower array type to a declared array narrows the reference (#190). A `mixed*` passes the assignability check because `mixed` is `any`, so it was adopted too and the variable widened past its declaration.

Narrowing now declines an assigned array whose element type is `any` when the declaration states a real one.

Worth noting the scalar path was already correct — `int r = some_mixed()` stays `int`. This was arrays diverging from established behaviour, not a new policy. #190's narrowing has a test pinning it.

## 4. `@returns` did not preserve the declarator's array rank

LPC declarators carry their own array rank, so a doc type is read as narrowing only the *element*. `getEffectiveTypeAnnotationNode` has handled this deliberately since #317:

> If the declarator is an array (e.g. `object *mobs`) but the JSDoc `@type` only narrows the element (e.g. `@type {STD_NPC}`), preserve the declarator's array rank…

`getEffectiveReturnTypeNode` never had it. So the two halves of one signature disagreed:

```
@param {T} arr  /  @returns {T}     on     mixed *f(mixed *arr)

  before:   string* f(string* arr)  ->  returns string     <- lost the *
  after:    string* f(string* arr)  ->  returns string*
```

The parameter kept its array rank and the return type quietly dropped it, so a generic efun handed back its *element* type instead of an array.

The rank-preserving logic is now a shared `preserveDeclaredArrayRank` helper used by both, gated on the same `shouldJsDocTypeOverrideTypeNode` check so a genuine mismatch — `string *f()` with `@returns {int}` — is still reported rather than silently coerced.

A consequence worth knowing: **both doc styles now work.** `@template T` + `@param {T}` + `@returns {T}` is correct and symmetric, as is the explicit `@param {T*}` form. The efuns below use the explicit form because it reads less ambiguously, not because the other is broken.

## 5. Array efun signatures did not relate their result to their input

A consistent gap across `arrays.h`, where `general.h` had already been done:

| efun | was | now |
|---|---|---|
| `sort_array` | `@template {ALL_ARRAY_TYPES} T` + `@param {T}`, on the first overload only | `@template T` + `@param {T*}` + `@returns {T*}`, on each of the three |
| `shuffle` | same pattern | same fix |
| `map_array` | no `@template` at all | `@template T, Y` with a `mapArrayCallback`, returns `Y*` |
| `filter_array` | no `@template` at all | `@template T`, reuses `filterCallback<T>`, returns `T*` |

The `sort_array` and `shuffle` docs were written against the wrong convention: `@template {ALL_ARRAY_TYPES} T` constrains `T` to whole *array* types, but on a `*`-declared parameter a doc type narrows the **element** (see #4). The result was an array-of-arrays and inference collapsed. `sort_array` compounded it by carrying its annotation on only the first of three overloads, so the `(arr, direction)` form callers reach most often was not generic at all.

Two things worth calling out:

- **`map_array` and `filter_array` need different generics.** Mapping transforms, so the result holds what the callback returns (`Y*`). Filtering selects, so the result holds the input element type (`T*`) and the callback's return value is only the keep-or-discard test. Using `Y*` for `filter_array` would have typed `filter_array(strings, (: strlen($1) > 2 :))` as `int*`.
- **The `string fun, object ob` overloads stay `mixed*` throughout.** The function is named by a string, so its return type is not knowable. That is correct rather than a gap.

Both patterns already existed in `general.h` — `map()` used the `@callback` form, `filter()` the single-parameter form — so this brings `arrays.h` in line rather than inventing anything, and `filterCallback<T>` is reused across the file boundary rather than duplicated.

`efuns/fluffos/zh-cn/arrays.zh-cn.h` carries the same four changes with its prose preserved, verified under `locale: "zh-cn"`. `mapCallback` and `filterCallback` already existed in `general.zh-cn.h`, so the cross-file references resolve there too.

A side effect worth having: because #354 gave inline closures real signatures, `$1` inside these callbacks is now contextually typed from the array's element type, and the callback's return type is what drives `map_array`'s result.

## Testing

- 30 new tests across `emptyArrayInitializer.spec.ts`, `arrayConcatElementTypes.spec.ts`, and `arrayDeclaredTypeRetention.spec.ts`, including the three declaration forms side by side so they cannot drift apart again.

## Notes for reviewers

**Existing mudlibs will see new diagnostics on code that compiled clean before.** All five fixes turn previously-silent situations into errors. That is the point, but it is a behavioral change rather than a pure internal cleanup, and the CHANGELOG entry should probably read as a fix rather than an enhancement.
