### PR TITLE
Add the 3-argument form of ed_start to the FluffOS efun stubs

### DIFF
--- a/efuns/fluffos/ed.h
+++ b/efuns/fluffos/ed.h
@@ -29,11 +29,20 @@ int query_ed_mode();
  * 
  * If restricted is 1, the commands that change which file is being edited
  * will be disabled.
- * 
+ *
+ * If scroll_lines is nonzero, it sets the number of lines displayed by the
+ * editor's scrolling commands (such as 'z').  The default is 20.
+ *
+ * When ed_start() is called with exactly two arguments, a second argument
+ * equal to 1 is treated as 'restricted'; any other value is treated as
+ * 'scroll_lines'.
+ *
  * Only one ed session can be active per object at a time.
  *
  */
 string ed_start(void|string file, void|int restricted);
+
+string ed_start(string file, int restricted, int scroll_lines);
 
 /**
  * ed_cmd() - send a command to an ed session

--- a/efuns/fluffos/zh-cn/ed.zh-cn.h
+++ b/efuns/fluffos/zh-cn/ed.zh-cn.h
@@ -25,11 +25,19 @@ int query_ed_mode();
  * 返回结果输出。编辑会话保持活跃，可以进一步调用 ed_cmd() 发送命令。
  * 
  * 如果 restricted 为1，则将禁用更改正在编辑的文件的命令。
- * 
+ *
+ * 如果 scroll_lines 为非零值，它设置编辑器滚动命令（如 'z'）
+ * 显示的行数。默认值为 20。
+ *
+ * 当 ed_start() 恰好以两个参数调用时，第二个参数等于 1 会被视为
+ * 'restricted'；其他任何值都会被视为 'scroll_lines'。
+ *
  * 每个对象一次只能有一个编辑会话处于活跃状态。
  *
  */
 string ed_start(void|string file, void|int restricted);
+
+string ed_start(string file, int restricted, int scroll_lines);
 
 /**
  * ed_cmd() - 向编辑会话发送命令


### PR DESCRIPTION
FluffOS's `ed_start` accepts an optional third argument per the efun spec in `src/packages/core/core.spec`:

```
string ed_start(string | void, int | void, int | void);
```

The third argument (`scroll_lines`) sets the number of lines shown by the editor's scrolling commands (such as `z`), defaulting to 20 — see `f_ed_start()` in `src/packages/core/ed.cc`. Because the stub only declares two parameters, 3-argument calls currently produce a spurious argument-count diagnostic.

This extends the signature in both the EN and zh-cn stub headers and documents the new argument, along with the driver's two-argument disambiguation rule (a second argument of exactly 1 is treated as `restricted`; any other value is treated as `scroll_lines`).

Companion FluffOS docs PR (the upstream doc page also only shows the two-argument form): fluffos/fluffos#1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)