### PR TITLE
Fix unstyled code in doc-comment @example blocks

### DIFF
--- a/syntaxes/lpc.tmLanguage.json
+++ b/syntaxes/lpc.tmLanguage.json
@@ -184,7 +184,7 @@
                     "name": "punctuation.separator.continuation.lpc"
                 },
                 {
-                    "include": "$base"
+                    "include": "$self"
                 }
             ]
         },
@@ -314,7 +314,7 @@
                     "include": "#block"
                 },
                 {
-                    "include": "$base"
+                    "include": "$self"
                 }
             ]
         },
@@ -405,7 +405,7 @@
             "name": "meta.parens.lpc",
             "patterns": [
                 {
-                    "include": "$base"
+                    "include": "$self"
                 }
             ]
         },
@@ -452,7 +452,7 @@
                     "end": "(?=^\\s*#\\s*endif\\b.*$)",
                     "patterns": [
                         {
-                            "include": "$base"
+                            "include": "$self"
                         }
                     ]
                 },
@@ -559,7 +559,7 @@
                     "end": "(?=^\\s*#\\s*(else|endif)\\b.*$)",
                     "patterns": [
                         {
-                            "include": "$base"
+                            "include": "$self"
                         }
                     ]
                 }
@@ -625,7 +625,7 @@
             "end": "^\\s*(#\\s*(endif)\\b).*$",
             "patterns": [
                 {
-                    "include": "$base"
+                    "include": "$self"
                 }
             ]
         },


### PR DESCRIPTION
## Problem

Inside `/** */` doc comments, code in `@example` blocks (and ```` ```lpc ```` fenced blocks) loses highlighting as soon as tokenization enters a construct whose innards are matched via `$base` — most visibly, string literals inside `({ ... })` array literals render as plain comment text while a bare string on the same line highlights fine:

Before: `has(player, "query_level")` highlights the string, but in `has(item, ({ "is_weapon", "is_armour" }))` the array strings fall through with only `meta.block.lpc` and no string scope.

## Cause

The grammar's recursion points (`parens`, `block_innards`, the `#define` body, and the three `preprocessor-rule-*` branches) recurse via `"include": "$base"`. In a plain LPC file `$base` and `$self` are the same grammar, so normal code is unaffected. But doc-comment examples embed `source.lpc.lang-server` through the `documentation.injection.lpc` injection grammar, and in that embedded instance vscode-textmate resolves `$base` to the injection grammar rather than the LPC grammar. The embedded LPC then has no string/paren/anything rules available inside those regions, so everything falls through unscoped.

## Fix

Replace the six `$base` includes with `$self`. Every one of them is LPC recursing into LPC, so `$self` is the correct reference regardless of how the grammar is embedded.

Verified by tokenizing with vscode-textmate + vscode-oniguruma using both grammars (with the injection registered):
- Array-literal strings in `@example` blocks now get `string.quoted.double.lpc` (and the `(`/`{` regions open properly as `meta.parens.lpc` / `meta.block.lpc`).
- Tokenization of regular (non-comment) code is byte-for-byte identical before and after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)