### PR TITLE
Fix two JSDoc tag parsing bugs: macro expansion inside doc types, and margin asterisks leaking into tag comments

### DIFF
--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -733,7 +733,11 @@ export namespace LpcParser {
 
         switch (incomingToken) {
             default:
-                if (allowMacroProcessing && (incomingToken == SyntaxKind.Identifier || isNonReservedKeyword(incomingToken))) {
+                // Inside a JSDoc comment, keywords are LPCDoc type vocabulary (`undefined`,
+                // `object`, `function`, ...) and must win over same-named macros (e.g. a
+                // mudlib's `#define undefined ([])[0]`); plain identifiers still expand so
+                // macro-valued doc types like `{STD_BODY}` keep resolving.
+                if (allowMacroProcessing && (incomingToken == SyntaxKind.Identifier || (isNonReservedKeyword(incomingToken) && !inContext(NodeFlags.JSDoc)))) {
                     const tokenValue = scanner.getTokenValue();
                     let macro: Macro;
         

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -6363,6 +6363,19 @@ export namespace LpcParser {
                     comments.push(text);
                     indent += text.length;
                 }
+                function tokenIsFirstOnLine(): boolean {
+                    const text = scanner.getText();
+                    for (let i = scanner.getTokenStart() - 1; i >= 0; i--) {
+                        const ch = text.charCodeAt(i);
+                        if (ch === CharacterCodes.lineFeed || ch === CharacterCodes.carriageReturn) {
+                            return true;
+                        }
+                        if (ch !== CharacterCodes.space && ch !== CharacterCodes.tab) {
+                            return false;
+                        }
+                    }
+                    return false;
+                }
                 if (initialMargin !== undefined) {
                     // jump straight to saving comments if there is some initial indentation
                     if (initialMargin !== "") {
@@ -6427,8 +6440,14 @@ export namespace LpcParser {
                             pushComment(scanner.getTokenValue());
                             break;
                         case SyntaxKind.AsteriskToken:
-                            if (state === JSDocState.BeginningOfLine) {
-                                // leading asterisks start recording on the *next* (non-whitespace) token
+                            if (state === JSDocState.BeginningOfLine || (comments.length === 0 && parts.length === 0 && tokenIsFirstOnLine())) {
+                                // Leading asterisks start recording on the *next* (non-whitespace)
+                                // token. The second test catches a stale entry token: a tag body
+                                // parsed with the regular (trivia-skipping) scanner, e.g. a @see
+                                // name reference, consumes the newline after it, so the next
+                                // line's margin asterisk arrives here without a preceding
+                                // NewLineTrivia. Its line position identifies it as margin, not
+                                // comment text.
                                 state = JSDocState.SawAsterisk;
                                 indent += 1;
                                 break;

--- a/server/src/tests/jsdocMacroTypes.spec.ts
+++ b/server/src/tests/jsdocMacroTypes.spec.ts
@@ -1,0 +1,101 @@
+import * as lpc from "./_namespaces/lpc.js";
+import { createTestLanguageService } from "./harness.js";
+
+function getDisplayString(quickInfo: lpc.QuickInfo | undefined): string {
+    return quickInfo?.displayParts?.map(p => p.text).join("") ?? "";
+}
+
+function getTag(quickInfo: lpc.QuickInfo | undefined, name: string): string | undefined {
+    const tag = quickInfo?.tags?.find(t => t.name === name);
+    return tag?.text?.map(p => p.text).join("");
+}
+
+describe("JSDoc types vs preprocessor macros", () => {
+    // A macro whose name collides with an LPCDoc type keyword (e.g. a mudlib's
+    // `#define undefined ([])[0]`) must not be expanded inside a doc type
+    // expression: the keyword wins there. Before the fix, the expansion derailed
+    // the type parse and the tag comment was sliced out of the macro body ("0]"),
+    // swallowing every tag that followed.
+    it("keyword in a doc type is not clobbered by a same-named macro", () => {
+        const source = `#define undefined ([])[0]
+
+/**
+ * Executes a previously assembled callback.
+ *
+ * @param {mixed*} cb - Callback array
+ * @returns {mixed|undefined} Result from callback execution
+ * @see valid_function
+ */
+mixed call_back(mixed *cb) {
+    return cb[0];
+}
+`;
+        const { ls, fileName } = createTestLanguageService({ "test.c": source });
+        const pos = source.indexOf("call_back(mixed");
+        const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
+
+        expect(getTag(quickInfo, "returns")).toBe("Result from callback execution");
+        // the derailed parse used to consume the rest of the comment too
+        expect(getTag(quickInfo, "see")).toContain("valid_function");
+    });
+
+    it("keyword macro collision is inert in leading type position too", () => {
+        // The first token after `{` is scanned while the brace is consumed;
+        // make sure the JSDoc context already applies there.
+        const source = `#define undefined ([])[0]
+
+/**
+ * @returns {undefined|string} Something or nothing
+ */
+string maybe() {
+    return 0;
+}
+`;
+        const { ls, fileName } = createTestLanguageService({ "test.c": source });
+        const pos = source.indexOf("maybe()");
+        const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
+
+        expect(getTag(quickInfo, "returns")).toBe("Something or nothing");
+    });
+
+    it("macros in code still expand when a doc comment is attached", () => {
+        const source = `#define undefined ([])[0]
+
+/**
+ * @returns {mixed|undefined} Something or nothing
+ */
+mixed maybe() {
+    return undefined;
+}
+`;
+        const { ls, fileName } = createTestLanguageService({ "test.c": source });
+        const pos = source.indexOf("maybe()");
+        const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
+
+        // doc tag survives...
+        expect(getTag(quickInfo, "returns")).toBe("Something or nothing");
+        // ...and the body still parses: `undefined` expanded to `([])[0]`, so the
+        // return expression is an element access, not a bare unresolved name
+        const syntactic = ls.getSyntacticDiagnostics(fileName);
+        expect(syntactic).toHaveLength(0);
+    });
+
+    // Plain-identifier macros in doc types are load-bearing: `{STD_BODY}` must
+    // keep expanding to its string value so it parses as a named object type.
+    it("identifier macro in a doc type still expands to a named object type", () => {
+        const source = `#define STD_BODY "/std/body"
+
+void test(/** @type {STD_BODY} */ object tp) {
+    tp;
+}
+`;
+        const { ls, fileName } = createTestLanguageService({
+            "test.c": source,
+            "std/body.c": "void query_name() {}\n",
+        });
+        const pos = source.indexOf("tp;");
+        const display = getDisplayString(ls.getQuickInfoAtPosition(fileName, pos));
+
+        expect(display).toContain('"/std/body"');
+    });
+});

--- a/server/src/tests/jsdocSeeTagComments.spec.ts
+++ b/server/src/tests/jsdocSeeTagComments.spec.ts
@@ -1,0 +1,86 @@
+import * as lpc from "./_namespaces/lpc.js";
+import { createTestLanguageService } from "./harness.js";
+
+function getTag(quickInfo: lpc.QuickInfo | undefined, name: string): string | undefined {
+    const tag = quickInfo?.tags?.find(t => t.name === name);
+    return tag?.text?.map(p => p.text).join("");
+}
+
+function getTags(quickInfo: lpc.QuickInfo | undefined, name: string): (string | undefined)[] {
+    return (quickInfo?.tags ?? [])
+        .filter(t => t.name === name)
+        .map(t => t.text?.map(p => p.text).join(""));
+}
+
+// A tag body parsed with the regular (trivia-skipping) scanner — e.g. a @see
+// name reference — consumes the newline after it, so the next doc line's
+// margin `*` used to be recorded as the tag's comment text: hovers rendered
+// "@see — other_func *".
+describe("JSDoc tag comments vs margin asterisks", () => {
+    it("@see followed by more tag lines has no stray asterisk", () => {
+        const source = `/**
+ * Does a thing.
+ *
+ * @see other_func
+ * @see third_func
+ * @example
+ * do_thing();
+ */
+void do_thing() {
+}
+`;
+        const { ls, fileName } = createTestLanguageService({ "test.c": source });
+        const pos = source.indexOf("void do_thing") + "void ".length;
+        const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
+
+        expect(getTags(quickInfo, "see")).toEqual(["other_func", "third_func"]);
+        expect(getTag(quickInfo, "example")).toBe("do_thing();");
+    });
+
+    it("@see continuation line keeps its text without the margin asterisk", () => {
+        const source = `/**
+ * @see other_func
+ * for details
+ */
+void do_thing() {
+}
+`;
+        const { ls, fileName } = createTestLanguageService({ "test.c": source });
+        const pos = source.indexOf("do_thing()");
+        const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
+
+        expect(getTag(quickInfo, "see")).toContain("for details");
+        expect(getTag(quickInfo, "see")).not.toContain("*");
+    });
+
+    it("description-less @param followed by another line has no stray asterisk", () => {
+        const source = `/**
+ * @param {int} x
+ * @see other_func
+ */
+void do_thing(int x) {
+}
+`;
+        const { ls, fileName } = createTestLanguageService({ "test.c": source });
+        const pos = source.indexOf("do_thing(int");
+        const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
+
+        expect(getTag(quickInfo, "param")).not.toContain("*");
+        expect(getTag(quickInfo, "see")).toBe("other_func");
+    });
+
+    it("a genuine mid-line asterisk in a tag comment is preserved", () => {
+        const source = `/**
+ * @returns {int} the product a * b
+ */
+int mul(int a, int b) {
+    return a * b;
+}
+`;
+        const { ls, fileName } = createTestLanguageService({ "test.c": source });
+        const pos = source.indexOf("mul(int");
+        const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
+
+        expect(getTag(quickInfo, "returns")).toBe("the product a * b");
+    });
+});


### PR DESCRIPTION
Two related parser fixes for how JSDoc/LPCDoc tag content survives into hovers.

## 1. Macros clobbering type keywords inside doc types

A mudlib macro named after an LPCDoc type keyword — e.g. a global include with

```c
#define undefined ([])[0]
```

— was macro-expanded *inside* JSDoc type expressions. With `@returns {mixed|undefined}`, the expansion derails the type parse and the tag comment gets sliced out of the macro body: the hover renders `@returns — 0]` (the tail of `([])[0]`) and **every tag after it is swallowed** (`@errors`, `@see`, `@example`...).

Fix: inside a JSDoc comment (`inContext(NodeFlags.JSDoc)`, which already spans the whole comment parse), non-reserved keywords win over same-named macros. Plain identifiers still expand, so macro-valued doc types like `/** @type {STD_BODY} */` keep resolving to named object types — that behavior is guarded by a test.

## 2. Next line's margin asterisk leaking into tag comments

A tag body parsed with the regular trivia-skipping scanner (e.g. a `@see` name reference) consumes the newline after it, so `parseTagComments` never sees a line break before the next doc line's margin `*` and records it as comment text — hovers render `@see — other_func *`. This is inherited from upstream TypeScript (still reproducible on 5.9.3 with two consecutive `@see` lines), but it's cheap to fix here: a first-token asterisk that is the first non-whitespace on its line is margin decoration, not comment text. A genuine mid-line `*` in a tag comment is unaffected (guarded by a test).

## Testing

- `jsdocMacroTypes.spec.ts`: keyword/macro collision in trailing and leading type position, macro still expanding in code bodies, and the `{STD_BODY}` named-object guard.
- `jsdocSeeTagComments.spec.ts`: consecutive `@see` tags, `@see` continuation lines, description-less `@param` followed by another tag, and preservation of a genuine mid-line asterisk.
- Full suite passes: 30 suites, 1015 tests, coverage thresholds met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)