### PR TITLE
Surface authored LPCDoc types in hover doc tags

### DIFF
--- a/server/src/lpcserver/textRendering.ts
+++ b/server/src/lpcserver/textRendering.ts
@@ -24,10 +24,11 @@ function getTagDocumentation(
         case 'param':
         case 'template': {
             const body = getTagBody(tag, filePathConverter);
-            if (body?.length === 3) {
-                const param = body[1];
-                const doc = body[2];
-                const label = `*@${tag.name}* \`${param}\``;
+            if (body?.length === 4) {
+                const type = body[1];
+                const param = body[2];
+                const doc = body[3];
+                const label = `*@${tag.name}* ${type ? `\`${type}\` ` : ''}\`${param}\``;
                 if (!doc) {
                     return label;
                 }
@@ -38,10 +39,24 @@ function getTagDocumentation(
         }
 
         case 'return':
-        case 'returns': {
+        case 'returns':
+        case 'throws': {
             // For return(s), we require a non-empty body
             if (!tag.text?.length) {
                 return undefined;
+            }
+
+            // Render a leading LPCDoc type (`{mixed|undefined} comment`) as a code
+            // span so the authored type is surfaced: `*@returns* `{...}` \u2014 comment`.
+            const text = getTagBodyText(tag, filePathConverter);
+            const typed = text?.match(/^(\{[^{}]*\})[ \t]*/);
+            if (text && typed) {
+                const rest = text.slice(typed[0].length);
+                const label = `*@${tag.name}* \`${typed[1]}\``;
+                if (!rest) {
+                    return label;
+                }
+                return label + (rest.match(/\r\n|\n/g) ? '  \n' + rest : ` \u2014 ${rest}`);
             }
 
             break;
@@ -65,10 +80,11 @@ function getTagBody(tag: Proto.JSDocTagInfo, filePathConverter: IFilePathToResou
         if (parts && typeof (parts) !== 'string') {
             const params = parts.filter(p => p.kind === 'typeParameterName').map(p => p.text).join(', ');
             const docs = parts.filter(p => p.kind === 'text').map(p => convertLinkTags(p.text.replace(/^\s*-?\s*/, ''), filePathConverter)).join(' ');
-            return params ? ['', params, docs] : undefined;
+            return params ? ['', undefined!, params, docs] : undefined;
         }
     }
-    return (convertLinkTags(tag.text, filePathConverter)).split(/^(\S+)\s*-?\s*/);
+    // Optional leading `{type}` (as emitted for property-like tags), then the name.
+    return (convertLinkTags(tag.text, filePathConverter)).split(/^(?:(\{[^{}]*\})[ \t]+)?(\S+)\s*-?\s*/);
 }
 
 /**

--- a/server/src/services/jsDoc.ts
+++ b/server/src/services/jsDoc.ts
@@ -63,6 +63,7 @@ import {
     JSDocTag,
     JSDocTagInfo,
     JSDocTemplateTag,
+    JSDocReturnTag,
     JSDocThrowsTag,
     JSDocTypedefTag,
     JSDocTypeTag,
@@ -262,6 +263,18 @@ export function getJsDocTagsFromDeclarations(declarations?: Declaration[], check
         for (const tag of tags) {
             infos.push({ name: tag.tagName.text, text: getCommentDisplayParts(tag, checker) });
             infos.push(...getJSDocPropertyTagsInfo(tryGetJSDocPropertyTags(tag), checker));
+            if (isJSDocOverloadTag(tag)) {
+                // The parser folds the @param/@returns tags that follow an @overload
+                // into its JSDocSignature; flatten them back out so each overload's
+                // members render beneath its *@overload* heading instead of vanishing.
+                for (const paramTag of tag.typeExpression.parameters) {
+                    infos.push({ name: paramTag.tagName.text, text: getCommentDisplayParts(paramTag, checker) });
+                }
+                const returnTag = tag.typeExpression.type;
+                if (returnTag) {
+                    infos.push({ name: returnTag.tagName.text, text: getCommentDisplayParts(returnTag, checker) });
+                }
+            }
         }
     });
     return infos;
@@ -292,7 +305,8 @@ function getCommentDisplayParts(tag: JSDocTag, checker?: TypeChecker): SymbolDis
     const displayParts: SymbolDisplayPart[] = [];
     switch (kind) {
         case SyntaxKind.JSDocThrowsTag:
-            const typeExpression = (tag as JSDocThrowsTag).typeExpression;
+        case SyntaxKind.JSDocReturnTag:
+            const typeExpression = (tag as JSDocThrowsTag | JSDocReturnTag).typeExpression;
             return typeExpression ? withNode(typeExpression) :
                 comment === undefined ? undefined : getDisplayPartsFromComment(comment, checker);
         case SyntaxKind.JSDocImplementsTag:
@@ -341,13 +355,20 @@ function getCommentDisplayParts(tag: JSDocTag, checker?: TypeChecker): SymbolDis
             //         displayParts.push(...withNode(typeExpression));
             //     }
             // }
-            const { name } = tag as JSDocTypedefTag | JSDocCallbackTag | JSDocPropertyTag | JSDocParameterTag | JSDocSeeTag;            
+            const { name } = tag as JSDocTypedefTag | JSDocCallbackTag | JSDocPropertyTag | JSDocParameterTag | JSDocSeeTag;
             if (name) {
-                displayParts.push(...withNode(name));
+                // Surface the authored LPCDoc type ahead of the name so hovers can
+                // render `@param {mixed*} cb — ...` instead of dropping the type.
+                if (isJSDocPropertyLikeTag(tag) && tag.typeExpression) {
+                    displayParts.push(textPart(tag.typeExpression.getText()), spacePart());
+                }
+                // preserve the [name] optional-parameter brackets from the source
+                const nameText = isJSDocPropertyLikeTag(tag) && tag.isBracketed ? `[${name.getText()}]` : name.getText();
+                displayParts.push(...addComment(nameText));
             } else if (comment) {
                 displayParts.push(...getDisplayPartsFromComment(comment, checker));
             }
-            
+
             return displayParts;
         default:
             return comment === undefined ? undefined : getDisplayPartsFromComment(comment, checker);

--- a/server/src/tests/jsdocMacroTypes.spec.ts
+++ b/server/src/tests/jsdocMacroTypes.spec.ts
@@ -34,7 +34,7 @@ mixed call_back(mixed *cb) {
         const pos = source.indexOf("call_back(mixed");
         const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
 
-        expect(getTag(quickInfo, "returns")).toBe("Result from callback execution");
+        expect(getTag(quickInfo, "returns")).toBe("{mixed|undefined} Result from callback execution");
         // the derailed parse used to consume the rest of the comment too
         expect(getTag(quickInfo, "see")).toContain("valid_function");
     });
@@ -55,7 +55,7 @@ string maybe() {
         const pos = source.indexOf("maybe()");
         const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
 
-        expect(getTag(quickInfo, "returns")).toBe("Something or nothing");
+        expect(getTag(quickInfo, "returns")).toBe("{undefined|string} Something or nothing");
     });
 
     it("macros in code still expand when a doc comment is attached", () => {
@@ -73,7 +73,7 @@ mixed maybe() {
         const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
 
         // doc tag survives...
-        expect(getTag(quickInfo, "returns")).toBe("Something or nothing");
+        expect(getTag(quickInfo, "returns")).toBe("{mixed|undefined} Something or nothing");
         // ...and the body still parses: `undefined` expanded to `([])[0]`, so the
         // return expression is an element access, not a bare unresolved name
         const syntactic = ls.getSyntacticDiagnostics(fileName);

--- a/server/src/tests/jsdocSeeTagComments.spec.ts
+++ b/server/src/tests/jsdocSeeTagComments.spec.ts
@@ -81,6 +81,6 @@ int mul(int a, int b) {
         const pos = source.indexOf("mul(int");
         const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
 
-        expect(getTag(quickInfo, "returns")).toBe("the product a * b");
+        expect(getTag(quickInfo, "returns")).toBe("{int} the product a * b");
     });
 });

--- a/server/src/tests/jsdocTagTypes.spec.ts
+++ b/server/src/tests/jsdocTagTypes.spec.ts
@@ -1,0 +1,127 @@
+import * as lpc from "./_namespaces/lpc.js";
+import { createTestLanguageService } from "./harness.js";
+import { tagsToMarkdown, IFilePathToResourceConverter } from "../lpcserver/textRendering.js";
+import { URI } from "vscode-uri";
+
+function getTag(quickInfo: lpc.QuickInfo | undefined, name: string): string | undefined {
+    const tag = quickInfo?.tags?.find(t => t.name === name);
+    return tag?.text?.map(p => p.text).join("");
+}
+
+const converter: IFilePathToResourceConverter = { toResource: filepath => URI.file(filepath) };
+
+/** Flatten LS tags the way the session does for hover (richResponse: false). */
+function toProtocolTags(quickInfo: lpc.QuickInfo | undefined) {
+    return (quickInfo?.tags ?? []).map(t => ({
+        name: t.name,
+        text: t.text?.map(p => p.text).join(""),
+    }));
+}
+
+// Authored LPCDoc types were dropped from hovers: `@returns {mixed|undefined}`
+// rendered as just `@returns — comment`, and `@param {mixed*} cb` as
+// `@param cb — comment`. The type now travels with the tag text and the
+// markdown renderer surfaces it as a code span.
+describe("LPCDoc types surfaced in hover tags", () => {
+    const source = `/**
+ * Executes a callback.
+ *
+ * @param {mixed*} cb - Callback array
+ * @param {...mixed} new_arg - Additional arguments to prepend
+ * @returns {mixed|undefined} Result from callback execution
+ * @throws {string} If the callback is malformed
+ */
+varargs mixed call_back(mixed *cb, mixed new_arg...) {
+    return cb[0];
+}
+`;
+
+    function hover() {
+        const { ls, fileName } = createTestLanguageService({ "test.c": source });
+        const pos = source.indexOf("call_back(mixed");
+        return ls.getQuickInfoAtPosition(fileName, pos);
+    }
+
+    it("tag text carries the authored type", () => {
+        const quickInfo = hover();
+        expect(getTag(quickInfo, "returns")).toBe("{mixed|undefined} Result from callback execution");
+        expect(getTag(quickInfo, "throws")).toBe("{string} If the callback is malformed");
+
+        const params = (quickInfo?.tags ?? [])
+            .filter(t => t.name === "param")
+            .map(t => t.text?.map(p => p.text).join(""));
+        expect(params).toEqual([
+            "{mixed*} cb - Callback array",
+            "{...mixed} new_arg - Additional arguments to prepend",
+        ]);
+    });
+
+    it("markdown rendering shows the type as a code span", () => {
+        const markdown = tagsToMarkdown(toProtocolTags(hover()) as any, converter);
+        expect(markdown).toContain("*@param* `{mixed*}` `cb` — Callback array");
+        expect(markdown).toContain("*@param* `{...mixed}` `new_arg` — Additional arguments to prepend");
+        expect(markdown).toContain("*@returns* `{mixed|undefined}` — Result from callback execution");
+        expect(markdown).toContain("*@throws* `{string}` — If the callback is malformed");
+    });
+
+    it("overload blocks surface their params and returns", () => {
+        // The parser folds @param/@returns following an @overload into that
+        // overload's JSDocSignature; they used to vanish from hovers entirely,
+        // leaving two bare `@overload` lines.
+        const source = `/**
+ * Creates a callback structure.
+ *
+ * @overload
+ * @param {object} ob - Target object.
+ * @param {string} method - Method name.
+ * @param {...mixed} [arg] - Extra arguments.
+ *
+ * @overload
+ * @param {function} f - Function pointer.
+ *
+ * @returns {mixed*} Assembled callback array.
+ * @see call_back
+ */
+mixed *assemble(mixed arg...) {
+    return ({ });
+}
+`;
+        const { ls, fileName } = createTestLanguageService({ "test.c": source });
+        const pos = source.indexOf("*assemble(mixed") + 1;
+        const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
+
+        const tags = (quickInfo?.tags ?? []).map(t => ({ name: t.name, text: t.text?.map(p => p.text).join("") }));
+        expect(tags).toEqual([
+            { name: "overload", text: undefined },
+            { name: "param", text: "{object} ob - Target object." },
+            { name: "param", text: "{string} method - Method name." },
+            { name: "param", text: "{...mixed} [arg] - Extra arguments." },
+            { name: "overload", text: undefined },
+            { name: "param", text: "{function} f - Function pointer." },
+            { name: "returns", text: "{mixed*} Assembled callback array." },
+            { name: "see", text: "call_back" },
+        ]);
+
+        const markdown = tagsToMarkdown(tags as any, converter);
+        expect(markdown).toContain("*@param* `{...mixed}` `[arg]` — Extra arguments.");
+        expect(markdown).toContain("*@returns* `{mixed*}` — Assembled callback array.");
+    });
+
+    it("typeless tags render as before", () => {
+        const bare = `/**
+ * @param cb - Callback array
+ * @returns Result of the call
+ */
+mixed call_it(mixed cb) {
+    return 0;
+}
+`;
+        const { ls, fileName } = createTestLanguageService({ "test.c": bare });
+        const pos = bare.indexOf("call_it(mixed");
+        const quickInfo = ls.getQuickInfoAtPosition(fileName, pos);
+        const markdown = tagsToMarkdown(toProtocolTags(quickInfo) as any, converter);
+
+        expect(markdown).toContain("*@param* `cb` — Callback array");
+        expect(markdown).toContain("*@returns* — Result of the call");
+    });
+});


### PR DESCRIPTION

LPCDoc types authored in doc comments never reached hovers:

- `@returns {mixed|undefined} Result...` rendered as just `@returns — Result...` — the type was dropped, even when it's richer than the declared signature type (unions with `undefined`, type predicates like `{f is function}`, named object types).
- `@param {mixed*} cb` likewise lost its type.
- `@overload` blocks were worse: the parser folds the following `@param`/`@returns` tags into the overload's `JSDocSignature`, and the services layer only rendered top-level tags — so overloaded docs rendered as two bare `@overload` lines with every param and the return doc silently discarded.

## Changes

**`services/jsDoc.ts`**
- `@returns` joins the existing `@throws` case: the tag text leads with the authored type expression.
- Property-like tags (`@param` etc.) prepend their `typeExpression` before the name.
- `@overload` tags flatten their signature's params/returns back out into the tag list beneath the `@overload` heading, so overloaded docs render in authored order.
- `[name]` optional-parameter brackets are preserved instead of being stripped.

**`lpcserver/textRendering.ts`**
- A leading `{type}` in param/returns/throws tag text renders as a code span: `*@param* `{mixed*}` `cb` — Callback array`, `*@returns* `{mixed|undefined}` — Result from callback execution`.
- Typeless tags render exactly as before (guarded by test).

Example hover after this change, for an overloaded sefun:

> *@overload*
> *@param* `{object}` `ob` — Target object to call a method on.
> *@param* `{string}` `method` — Method name to invoke on ob.
> *@param* `{...mixed}` `[arg]` — Additional arguments to forward to the method.
> *@overload*
> *@param* `{function}` `f` — Function pointer to invoke.
> *@param* `{...mixed}` `[arg]` — Additional arguments to forward to the function.
> *@returns* `{mixed*}` — Assembled callback array.

## Testing

New `jsdocTagTypes.spec.ts`: typed tag text, markdown rendering, overload flattening with bracket preservation, and a typeless-tags-unchanged guard. Existing spec expectations updated for the type-carrying tag text. Full suite: 32 suites, 1020 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
