### PR TITLE
fix(hover): print float as `float`, not `int`

### DIFF
--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -20312,6 +20312,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return factory.createKeywordTypeNode(SyntaxKind.StringKeyword);
             }
             if (type.flags & TypeFlags.Number) {
+                // `floatType` carries TypeFlags.Number too (so int and float share numeric
+                // behavior), so it has to be distinguished by identity here or it would
+                // print as `int`.
+                if (type === floatType) {
+                    context.approximateLength += 5;
+                    return factory.createKeywordTypeNode(SyntaxKind.FloatKeyword);
+                }
                 context.approximateLength += 6;
                 return factory.createKeywordTypeNode(SyntaxKind.IntKeyword);
             }

--- a/server/src/tests/quickinfo.spec.ts
+++ b/server/src/tests/quickinfo.spec.ts
@@ -70,6 +70,36 @@ void test() {
         expect(callDisplay).toContain("int");
     });
 
+    it("shows float (not int) for float declarations, calls and variables", () => {
+        // `floatType` is created with TypeFlags.Number so that int and float share numeric
+        // behavior, which made the type printer fall into the `int` branch for anything
+        // typed float: `float percent_of(...)` hovered as `function int percent_of(...)`.
+        const source = `float percent_of(float a, float b) {
+    return (a / 100.0) * b;
+}
+
+void test() {
+    float red = percent_of(1.0, 2.0);
+    float *all = ({ red });
+}
+`;
+        const { ls, fileName } = createLanguageService(source);
+
+        for (const pos of [source.indexOf("percent_of"), source.indexOf("percent_of(1.0")]) {
+            const display = getDisplayString(ls.getQuickInfoAtPosition(fileName, pos)!);
+            expect(display).toContain("float percent_of");
+            expect(display).not.toContain("int");
+        }
+
+        const varDisplay = getDisplayString(ls.getQuickInfoAtPosition(fileName, source.indexOf("red =") )!);
+        expect(varDisplay).toContain("float");
+        expect(varDisplay).not.toContain("int");
+
+        const arrDisplay = getDisplayString(ls.getQuickInfoAtPosition(fileName, source.indexOf("all ="))!);
+        expect(arrDisplay).toContain("float");
+        expect(arrDisplay).not.toContain("int");
+    });
+
     it("infers nested-mapping value type in foreach, not mixed*", () => {
         // https://github.com/jlchmura/lpc-language-server/issues/319
         const source = `mapping DIRECTIONS = ([


### PR DESCRIPTION
Anything typed `float` displayed as `int` in quick info. A simul_efun declared
`float percent_of(float a, float b)` hovered as:

```
function int percent_of(float a, float b)
```

Only the return type flips in a signature, which makes it look like a
declaration-vs-doc mismatch — parameters render from their declaration's type
nodes, while the return type goes through the type printer. The same bug hit
`float` locals, parameters and `float *` arrays:

| | before | after |
|---|---|---|
| `float f(float a)` | `function int f(float a)` | `function float f(float a)` |
| `float *f(float a)` | `function int* f(float a)` | `function float* f(float a)` |
| `float x` local | `(local var) int x` | `(local var) float x` |
| `float a` parameter | `(parameter) int a` | `(parameter) float a` |

## Cause

`floatType` is created with `TypeFlags.Number`, the same flag as `intType`, so
that int and float share numeric behavior:

```ts
var intType   = createIntrinsicType(TypeFlags.Number, "int");
var floatType = createIntrinsicType(TypeFlags.Number, "float");
```

But `typeToTypeNodeHelper` maps types to keywords by flag and tests
`TypeFlags.Number` first, so `floatType` took the `int` branch — and the
`TypeFlags.Float` branch below it was unreachable, since no type actually
carries that flag (`NumberLike` doesn't include it either).

## Fix

Distinguish `floatType` by identity inside the `Number` branch. Giving
`floatType` the `Float` flag instead would ripple through assignability and
`NumberLike` membership, so this keeps the blast radius to the printer.

This likely also affected diagnostic text — an int/float mismatch would have
read `Type 'int' is not assignable to type 'int'`.

## Testing

New `QuickInfo` case covering the declaration, the call site, a `float` local
and a `float *` array. Full suite passes: 1020 tests, 31 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)