### PR TITLE
Keep the return type of efun:: calls, and resolve config macros in hover doc tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # LPC Language Services Changelog
 
+## 1.1.52
+
+- Fix: efuns were always returning mixed type, even when the efun signature specified a return type.
+- Fix: efun hover did not resolve macros
+- Fix: hover should print `float` as `float` not `int`
+- Surface authored LPCDoc types in hover doc tags- #361
+- Fix: Two JSDoc tag parsing bugs: macro expansion inside doc types, and margin asterisks leaking into tag comments- #360
+
 ## 1.1.51
 
 - Fix: unstyled code in doc-comment @example blocks - #359

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -14889,8 +14889,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // grammar
         const sourceFile = getSourceFileOfNode(node);
         const sourceSymbol = getSymbolOfNode(sourceFile);
-        if (!sourceSymbol.inherits?.size && (!node.namespace || getTextOfNode(node.namespace) !== InternalSymbolName.EfunSuperPrefix)) {
+        const isEfunPrefix = !!node.namespace && getTextOfNode(node.namespace) === InternalSymbolName.EfunSuperPrefix;
+        if (!sourceSymbol.inherits?.size && !isEfunPrefix) {
             error(node, Diagnostics.Super_access_can_only_be_used_in_a_file_that_inherits_from_another_file);
+        }
+
+        // `efun::foo()` names the efun directly and has nothing to do with the inheritance
+        // chain, so it must not be held to the base-type requirement below. A file with no
+        // `inherit` -- a simul-efun override being the usual case -- otherwise fell out with
+        // errorType, and every `efun::` call in it silently evaluated to `mixed`.
+        if (isEfunPrefix) {
+            return checkIdentifier(node.name, checkMode);
         }
 
         // type

--- a/server/src/services/jsDoc.ts
+++ b/server/src/services/jsDoc.ts
@@ -90,9 +90,11 @@ import {
     SyntaxKind,
     TextInsertion,
     textPart,
+    JSDocTypeExpression,
     typeAliasNamePart,
     TypeChecker,
     typeParameterNamePart,
+    typeToDisplayParts,
     VariableStatement,
 } from "./_namespaces/lpc.js";
 
@@ -307,7 +309,7 @@ function getCommentDisplayParts(tag: JSDocTag, checker?: TypeChecker): SymbolDis
         case SyntaxKind.JSDocThrowsTag:
         case SyntaxKind.JSDocReturnTag:
             const typeExpression = (tag as JSDocThrowsTag | JSDocReturnTag).typeExpression;
-            return typeExpression ? withNode(typeExpression) :
+            return typeExpression ? addComment(typeExpressionText(typeExpression)) :
                 comment === undefined ? undefined : getDisplayPartsFromComment(comment, checker);
         case SyntaxKind.JSDocImplementsTag:
             return withNode((tag as JSDocImplementsTag).class);
@@ -360,7 +362,7 @@ function getCommentDisplayParts(tag: JSDocTag, checker?: TypeChecker): SymbolDis
                 // Surface the authored LPCDoc type ahead of the name so hovers can
                 // render `@param {mixed*} cb — ...` instead of dropping the type.
                 if (isJSDocPropertyLikeTag(tag) && tag.typeExpression) {
-                    displayParts.push(textPart(tag.typeExpression.getText()), spacePart());
+                    displayParts.push(textPart(typeExpressionText(tag.typeExpression)), spacePart());
                 }
                 // preserve the [name] optional-parameter brackets from the source
                 const nameText = isJSDocPropertyLikeTag(tag) && tag.isBracketed ? `[${name.getText()}]` : name.getText();
@@ -376,6 +378,32 @@ function getCommentDisplayParts(tag: JSDocTag, checker?: TypeChecker): SymbolDis
 
     function withNode(node: Node) {
         return addComment(node.getText());
+    }
+
+    /**
+     * The text to show for a doc tag's `{type}`.
+     *
+     * Authored types are surfaced exactly as written -- `{mixed|undefined}` stays that way
+     * rather than collapsing to what it resolves to, because the annotation is the useful
+     * thing. The exception is a config-injected macro: `@returns {__LPC_CONFIG_LIBFILES_PLAYER*}`
+     * names a path the project settings supply, so unlike a mudlib's own `STD_NPC` the name
+     * carries no meaning for a reader, and printing it contradicts the signature line above
+     * which already shows the resolved type.
+     *
+     * Note the macro is deliberately not expanded when the doc type is *parsed* -- a mudlib
+     * `#define undefined` would otherwise clobber the type keyword -- so this substitution
+     * happens at display time only.
+     */
+    function typeExpressionText(typeExpression: JSDocTypeExpression): string {
+        const authored = typeExpression.getText();
+        if (checker && typeExpression.type && /\b__LPC_CONFIG_[A-Z0-9_]*\b/.test(authored)) {
+            const resolved = checker.getTypeFromTypeNode(typeExpression.type);
+            const text = resolved && typeToDisplayParts(checker, resolved, typeExpression)?.map(p => p.text).join("");
+            if (text) {
+                return `{${text}}`;
+            }
+        }
+        return authored;
     }
 
     function addComment(s: string) {

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -272,6 +272,24 @@ exports[`Compiler compiler/doWhile.c Reports correct errors for compiler/doWhile
 
 exports[`Compiler compiler/efun.fluff.filter.c Reports correct errors for compiler/efun.fluff.filter.c: diags-compiler/efun.fluff.filter.c 1`] = `""`;
 
+exports[`Compiler compiler/efunSuperOverloadResolution.c Reports correct errors for compiler/efunSuperOverloadResolution.c: diags-compiler/efunSuperOverloadResolution.c 1`] = `""`;
+
+exports[`Compiler compiler/efunSuperReturnType.c Reports correct errors for compiler/efunSuperReturnType.c: diags-compiler/efunSuperReturnType.c 1`] = `
+"
+Found 1 error in server/src/tests/cases/compiler/efunSuperReturnType.c[90m:13[0m
+
+"
+`;
+
+exports[`Compiler compiler/efunSuperReturnTypeInherit.base.c Reports correct errors for compiler/efunSuperReturnTypeInherit.base.c: diags-compiler/efunSuperReturnTypeInherit.base.c 1`] = `""`;
+
+exports[`Compiler compiler/efunSuperReturnTypeInherit.c Reports correct errors for compiler/efunSuperReturnTypeInherit.c: diags-compiler/efunSuperReturnTypeInherit.c 1`] = `
+"
+Found 1 error in server/src/tests/cases/compiler/efunSuperReturnTypeInherit.c[90m:9[0m
+
+"
+`;
+
 exports[`Compiler compiler/error1.c Reports correct errors for compiler/error1.c: diags-compiler/error1.c 1`] = `""`;
 
 exports[`Compiler compiler/error2.c Reports correct errors for compiler/error2.c: diags-compiler/error2.c 1`] = `""`;

--- a/server/src/tests/cases/compiler/efunSuperOverloadResolution.c
+++ b/server/src/tests/cases/compiler/efunSuperOverloadResolution.c
@@ -1,0 +1,13 @@
+// An `efun::` call that lost its return type took the surrounding call down with it.
+//
+// filter() overloads on array vs string|mapping. With `efun::all_inventory()` evaluating to
+// `mixed`, the array overload never matched and resolution fell through to the string|mapping
+// form, reporting that `string | mapping` was not assignable to an object array -- which read
+// as a bug in filter's signature rather than in the efun:: call feeding it.
+
+object *interactive_contents() {
+    return filter(efun::all_inventory(), (: $1 :));
+}
+
+// @driver: fluffos
+// @errors: 0

--- a/server/src/tests/cases/compiler/efunSuperReturnType.c
+++ b/server/src/tests/cases/compiler/efunSuperReturnType.c
@@ -1,0 +1,20 @@
+// `efun::foo()` must keep its return type in a file that inherits nothing.
+//
+// checkSuperExpression bails with errorType when the containing file has no base type --
+// right for `::name` and `Parent::name`, which resolve against the inheritance chain, but
+// `efun::name` names an efun directly and has nothing to do with inheritance. The bail-out
+// ran before the fallback that handles it, so every `efun::` call in such a file evaluated
+// to `mixed`. Simul-efun overrides, which use the form most, typically inherit nothing.
+//
+// super2.c already covers that the form is *allowed* here; this covers that it is typed.
+
+test() {
+    // explode() returns string*, so this is a real mismatch and must be reported
+    int *bad = efun::explode("a", ",");
+
+    // ... and the matching assignment must not be
+    string *good = efun::explode("a", ",");
+}
+
+// @driver: fluffos
+// @errors: 1

--- a/server/src/tests/cases/compiler/efunSuperReturnTypeInherit.base.c
+++ b/server/src/tests/cases/compiler/efunSuperReturnTypeInherit.base.c
@@ -1,0 +1,3 @@
+string base_name() {
+    return "base";
+}

--- a/server/src/tests/cases/compiler/efunSuperReturnTypeInherit.c
+++ b/server/src/tests/cases/compiler/efunSuperReturnTypeInherit.c
@@ -1,0 +1,17 @@
+// The companion to efunSuperReturnType.c: a file that *does* inherit must resolve `efun::`
+// the same way. The fix skips the base-type requirement for the efun prefix, so this guards
+// that it did not become a special case that only works when there is no base type.
+
+inherit "efunSuperReturnTypeInherit.base.c";
+
+test() {
+    // explode() returns string*, so this is a real mismatch and must be reported
+    int *bad = efun::explode("a", ",");
+
+    // the inherited member still resolves through ordinary super access
+    string n = ::base_name();
+}
+
+// @driver: fluffos
+// @files: efunSuperReturnTypeInherit.base.c
+// @errors: 1

--- a/server/src/tests/docTagConfigMacro.spec.ts
+++ b/server/src/tests/docTagConfigMacro.spec.ts
@@ -1,0 +1,53 @@
+import * as lpc from "./_namespaces/lpc.js";
+import * as path from "path";
+import { createTestLanguageService } from "./harness.js";
+
+/**
+ * Doc tag types are surfaced exactly as authored -- `{mixed|undefined}` stays that way rather
+ * than collapsing to what it resolves to, because the annotation is the useful thing. See
+ * jsdocTagTypes.spec.ts, which pins that contract.
+ *
+ * Config-injected macros are the exception. `@returns {__LPC_CONFIG_LIBFILES_PLAYER*}` names a
+ * path the project settings supply, so unlike a mudlib's own `STD_NPC` the name carries nothing
+ * for a reader, and printing it contradicts the signature line above which already shows the
+ * resolved type.
+ *
+ * The substitution is display-only: macros are deliberately not expanded when a doc type is
+ * *parsed*, because a mudlib `#define undefined` would clobber the type keyword and swallow
+ * every tag that followed (see jsdocMacroTypes.spec.ts).
+ */
+const cwd = lpc.normalizePath(process.cwd());
+
+function tagsFor(files: Record<string, string>, marker: string, extraOptions?: Partial<lpc.CompilerOptions>): string {
+    const { ls, abs } = createTestLanguageService(files, {
+        driverType: lpc.LanguageVariant.FluffOS,
+        diagnostics: true,
+        rootDir: path.join(cwd, "lib"),
+        ...extraOptions,
+    } as Partial<lpc.CompilerOptions>);
+    const source = files["lib/test.c"];
+    const tags = ls.getQuickInfoAtPosition(abs("lib/test.c"), source.indexOf(marker))?.tags ?? [];
+    return tags.map(t => `@${t.name} ${t.text?.map(x => x.text).join("")}`).join(" ");
+}
+
+describe("config-injected macros in doc tag types", () => {
+    it("shows the resolved type rather than the macro name", () => {
+        // The efun `users()` is declared `@returns {__LPC_CONFIG_LIBFILES_PLAYER*}`.
+        const text = tagsFor(
+            { "lib/std/user.c": `string query_name() { return "x"; }\n`, "lib/test.c": `void t() { users(); }\n` },
+            "users()",
+            { playerFile: "/std/user.c" },
+        );
+        expect(text).not.toContain("__LPC_CONFIG_LIBFILES_PLAYER");
+        expect(text).toContain("An array of objects");
+    });
+
+    it("leaves an ordinary authored type alone", () => {
+        const files = {
+            "lib/test.c": `/**\n * plain\n * @param {mixed*} cb - the callback\n * @returns {string*} some strings\n */\nstring *plain(mixed *cb);\n\nvoid t() { plain(0); }\n`,
+        };
+        const text = tagsFor(files, "plain(0)");
+        expect(text).toContain("{string*}");
+        expect(text).toContain("{mixed*}");
+    });
+});


### PR DESCRIPTION
## Summary

Two fixes that showed up together in a simul-efun override: an `efun::` call silently lost its return type, and a config macro leaked into the hover text next to it.

```lpc
// lib/secure/sefun/override.c -- inherits nothing, as sefun overrides usually don't
object *users() {
    return filter(efun::users(), (: $1 && $1->query_name() :));
}
```

This reported `Type 'string | mapping' is not assignable to type 'object "/std/user"*'`, which reads as a bug in `filter`'s signature. It isn't — `filter` was handed `mixed`.

## 1. `efun::` calls lost their return type in files with no `inherit`

`checkSuperExpression` bails out with `errorType` when the containing file has no base type. That is correct for `::name` and `Parent::name`, which resolve against the inheritance chain — but `efun::name` names an efun directly and has nothing to do with inheritance, and the bail-out ran *before* the fallback that handles the efun prefix.

The result: in any file without an `inherit`, every `efun::` call evaluated to `mixed`. Simul-efun overrides are the files that use the form most, and they typically inherit nothing, so the type was lost exactly where the form is most used.

```lpc
mixed r = efun::explode("a", ",");

// before:  no inherit -> mixed        with inherit -> string*
// after:   both -> string*
```

The knock-on effect is what made this hard to read. `filter` overloads on array vs `string|mapping`. Given `mixed`, the array overload never matched and resolution fell through to the `string|mapping` form, so the error pointed at the result type of a perfectly good call.

The grammar guard is untouched: `::create()` in a non-inheriting file still reports "Super access can only be used in a file that inherits from another file" (`super1.c`), and inherited `::` still resolves to the parent's member.

## 2. Config-injected macros were printed raw in hover doc tags

`users()` is declared `@returns {__LPC_CONFIG_LIBFILES_PLAYER*}` — a path the project's `lpc-config.json` supplies. The hover's signature line resolved it to `object "/std/user"*`, but the tag underneath printed the macro name, contradicting the line above it and telling the reader nothing.

The fix is narrower than it first appears, because two existing behaviours constrain it:

- **Authored types are surfaced verbatim** (#361). `{mixed|undefined}` must stay that way rather than collapsing to what it resolves to, since the annotation is the useful part. My first attempt rendered the resolved type for every tag and broke seven tests in `jsdocTagTypes.spec.ts`.
- **Macros are deliberately not expanded when a doc type is parsed** (`jsdocMacroTypes.spec.ts`). A mudlib's `#define undefined` would otherwise clobber the type keyword and swallow every tag after it.

So the substitution is scoped to `__LPC_CONFIG_*` macros and happens at display time only. Those are compiler-injected from project settings, never user-written, and opaque to a reader — whereas a mudlib's own `STD_NPC` is a meaningful name worth showing exactly as authored. Braces are preserved so the tag keeps the established `{type}` shape.

## Testing

- `npm test` — 32 suites, 1034 tests, 278 snapshots pass.
- Three new compiler cases, since the `efun::` behaviour is expressible as error counts:
  - `efunSuperReturnType.c` — `int *bad = efun::explode(...)` is reported and `string *good = ...` is not, which is what proves the return type is real rather than `mixed`.
  - `efunSuperOverloadResolution.c` — the reported case: `filter(efun::all_inventory(), ...)` into an `object*` is clean.
  - `efunSuperReturnTypeInherit.c` — the same resolution in a file that *does* inherit, plus `::base_name()` still working.
- **Two of the three fail without the fix** (verified by reverting it). The inherit variant passes either way by design — it guards against the fix becoming a no-inherit special case rather than acting as a regression test, and the file says so.
- One new LS spec, `docTagConfigMacro.spec.ts`, for the hover half. That one genuinely needs the language service: it reads `quickInfo.tags` and needs `playerFile` set for the macro to exist at all.

These complement the existing `super1.c` (the grammar guard) and `super2.c`, which covered that `efun::` is *allowed* in a non-inheriting file but not that it is typed — `write()` returns void, so nothing typed was exercised there.

## Notes for reviewers

**The doc-tag rule is deliberately narrow.** It fixes config macros and cannot disturb user macros. The broader alternative — resolving every macro in doc types — conflicts with the authored-verbatim contract above and would need those tests revisited. That is a design call rather than an oversight, and worth a second opinion.

**`docTagConfigMacro.spec.ts` sits between two existing contracts** and its header says which, so the next person to touch it does not "simplify" it into breaking one.
