### PR TITLE
fix: FluffOS keyword gating, *p() narrowing predicates, and new(struct Foo)

### DIFF
--- a/efuns/fluffos/buffers.h
+++ b/efuns/fluffos/buffers.h
@@ -74,8 +74,8 @@ int crc32( buffer | string x );
 /**
  * bufferp() - identifies whether a given variable is a buffer
  *
- * Return 1 if 'arg' is a buffer value and zero (0) otherwise.
- *
+ * @returns {arg is buffer} 1 if 'arg' is a buffer value and zero (0) otherwise.
+ * @example
  * int is_buffer = bufferp( allocate_buffer(10) ); // 1
  * int is_buffer = bufferp( "Foo" ); // 0
  *

--- a/efuns/fluffos/floats.h
+++ b/efuns/fluffos/floats.h
@@ -80,8 +80,7 @@ float floor( float f );
 /**
  * floatp() - determine whether or not a given variable is a float
  *
- * Return 1 if 'arg' is a float number and zero (0) otherwise.
- *
+ * @returns {arg is float} 1 if 'arg' is a float number and zero (0) otherwise.
  */
 int floatp( mixed arg );
 

--- a/efuns/fluffos/general.h
+++ b/efuns/fluffos/general.h
@@ -12,7 +12,7 @@
  * 2.  it  is  a variable set equal to the return value of an access of an
  * element  in  a   mapping   that   doesn't   exist   (e.g.   arg   =
  * map[not_there]).
- *
+ * @returns {arg is 0} 1 if the variable is undefined, 0 otherwise
  */
 int undefinedp( mixed arg );
 

--- a/efuns/fluffos/interactive.h
+++ b/efuns/fluffos/interactive.h
@@ -216,7 +216,7 @@ varargs void say( string str, object obj );
  *
  */
 int resolve( string address, string callback_func );
-int resolve( string address, closure callback_func );
+int resolve( string address, function callback_func );
 
 /**
  * remove_action - unbind a command verb from a local function

--- a/efuns/fluffos/mappings.h
+++ b/efuns/fluffos/mappings.h
@@ -55,8 +55,7 @@ mixed match_path( mapping m, string str );
 /**
  * mapp() - determine whether or not a given variable is a mapping
  *
- * Return 1 if 'arg' is a mapping.
- *
+ * @returns {arg is mapping} 1 if 'arg' is a mapping.
  */
 int mapp( mixed arg );
 

--- a/efuns/fluffos/numbers.h
+++ b/efuns/fluffos/numbers.h
@@ -34,8 +34,7 @@ int random( int n );
 /**
  * intp() - determine whether or not a given variable is an integer
  *
- * Return 1 if 'arg' is an integer number and zero (0) otherwise.
- *
+ * @returns {arg is int} 1 if 'arg' is an integer number and zero (0) otherwise.
  */
 int intp( mixed arg );
 

--- a/efuns/fluffos/zh-cn/buffers.zh-cn.h
+++ b/efuns/fluffos/zh-cn/buffers.zh-cn.h
@@ -64,8 +64,8 @@ int crc32( buffer | string x );
 /**
  * bufferp() - 确定给定变量是否是一个缓冲区
  *
- * 如果 'arg' 是一个缓冲区值，则返回 1，否则返回零 (0)。
- *
+ * @returns {arg is buffer} 如果 'arg' 是一个缓冲区值，则返回 1，否则返回零 (0)。
+ * @example
  * int is_buffer = bufferp( allocate_buffer(10) ); // 1
  * int is_buffer = bufferp( "Foo" ); // 0
  *

--- a/efuns/fluffos/zh-cn/floats.zh-cn.h
+++ b/efuns/fluffos/zh-cn/floats.zh-cn.h
@@ -75,8 +75,7 @@ float floor( float f );
 /**
  * floatp() - 确定给定变量是否为浮点数
  *
- * 如果 'arg' 是浮点数，则返回 1，否则返回 0。
- *
+ * @returns {arg is float} 如果 'arg' 是浮点数，则返回 1，否则返回 0。
  */
 int floatp( mixed arg );
 

--- a/efuns/fluffos/zh-cn/general.zh-cn.h
+++ b/efuns/fluffos/zh-cn/general.zh-cn.h
@@ -8,7 +8,7 @@
  * 1. 它是一个变量，其值等于对一个不存在的方法的 call_other 调用的返回值（例如 arg = call_other(obj, "???")）。
  * 
  * 2. 它是一个变量，其值等于对一个不存在的映射元素的访问的返回值（例如 arg = map[not_there]）。
- *
+ * @returns {arg is 0} 如果变量未定义，则返回 1，否则返回 0
  */
 int undefinedp( mixed arg );
 

--- a/efuns/fluffos/zh-cn/interactive.zh-cn.h
+++ b/efuns/fluffos/zh-cn/interactive.zh-cn.h
@@ -203,7 +203,7 @@ varargs void say( string str, object obj );
  *
  */
 int resolve( string address, string callback_func );
-int resolve( string address, closure callback_func );
+int resolve( string address, function callback_func );
 
 /**
  * remove_action - 取消绑定一个命令动词到本地函数

--- a/efuns/fluffos/zh-cn/mappings.zh-cn.h
+++ b/efuns/fluffos/zh-cn/mappings.zh-cn.h
@@ -49,8 +49,7 @@ mixed match_path( mapping m, string str );
 /**
  * mapp() - 确定给定变量是否为映射
  *
- * 如果 'arg' 是一个映射，则返回 1。
- *
+ * @returns {arg is mapping} 如果 'arg' 是一个映射，则返回 1。
  */
 int mapp( mixed arg );
 

--- a/efuns/fluffos/zh-cn/numbers.zh-cn.h
+++ b/efuns/fluffos/zh-cn/numbers.zh-cn.h
@@ -30,7 +30,6 @@ int random( int n );
 /**
  * intp() - 确定给定变量是否是整数
  *
- * 如果 'arg' 是一个整数，则返回 1，否则返回零（0）。
- *
+ * @returns {arg is int} 如果 'arg' 是一个整数，则返回 1，否则返回零（0）。
  */
 int intp( mixed arg );

--- a/efuns/ldmud/efun.h
+++ b/efuns/ldmud/efun.h
@@ -1528,7 +1528,7 @@ float tan(int|float f);
 /**
  * symbolp
  *
- * Returns true, if arg is a symbol.
+ * @returns {arg is symbol} 1 if arg is a symbol.
  *
  * @example 
  * symbolp('foo) returns 1.
@@ -5320,7 +5320,7 @@ varargs mapping m_add(mapping map, mixed key, varargs mixed data);
 /**
  * lwobjectp
  *
- * Return 1 if arg is a lightweight object.
+ * @returns {arg is lwobject} 1 if arg is a lightweight object.
  *
  *
  */
@@ -9236,7 +9236,7 @@ int command(string str, object ob);
 /**
  * closurep
  *
- * Returns 1 if the argument is a closure.
+ * @returns {c is closure} 1 if the argument is a closure.
  *
  * @since Introduced in 3.2@70
  *
@@ -9982,7 +9982,7 @@ mixed call_coroutine(coroutine cr, mixed value = 0);
 /**
  * bytesp
  *
- * Return 1 if arg is a byte sequence.
+ * @returns {arg is bytes} 1 if arg is a byte sequence.
  *
  * @since Introducted in LDMud 3.6.0.
  *

--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -5729,10 +5729,13 @@ export namespace LpcParser {
       
         parseExpected(SyntaxKind.OpenParenToken);
         
-        if (token() == SyntaxKind.ClassKeyword) {
+        if (token() == SyntaxKind.ClassKeyword || token() == SyntaxKind.StructKeyword) {
             // fluff-style new class constructor
             // class Foo = new(class Foo);
             // class Foo = new(class Foo, name: "Bob", age: 42);
+            // `struct` is the same keyword in FluffOS -- lexer_utils.cc maps both
+            // "class" and "struct" to L_CLASS -- and `new` is FluffOS-only, so
+            // accepting either spelling here needs no driver gate.
             expression = parseType();
 
             if (parseOptional(SyntaxKind.CommaToken)) {

--- a/server/src/compiler/scanner.ts
+++ b/server/src/compiler/scanner.ts
@@ -1967,7 +1967,8 @@ export function createScanner(
     // Some reserved words are driver-specific: `buffer` and `class` are types, `new` is
     // the object-construction operator, and `ref` marks a by-reference parameter, only in
     // FluffOS (LDMud uses `struct` for structures, `clone_object()` to construct, and `&`
-    // for by-reference); `status` and `symbol` are types only in LDMud; `time_expression`
+    // for by-reference); `bytes`, `closure`, `lwobject`, `status` and `symbol` are types,
+    // and `deprecated` and `virtual` are modifiers, only in LDMud; `time_expression`
     // is a reserved word only in FluffOS. In the other driver each is an ordinary
     // identifier (e.g. a variable or function name), so demote it to an Identifier token
     // here rather than gating it per grammar position downstream.
@@ -1979,8 +1980,13 @@ export function createScanner(
             case SyntaxKind.RefKeyword:
             case SyntaxKind.TimeExpressionKeyword:
                 return variant === LanguageVariant.FluffOS;
+            case SyntaxKind.BytesKeyword:
+            case SyntaxKind.ClosureKeyword:
+            case SyntaxKind.DeprecatedKeyword:
+            case SyntaxKind.LwObjectKeyword:
             case SyntaxKind.StatusKeyword:
             case SyntaxKind.SymbolKeyword:
+            case SyntaxKind.VirtualKeyword:
                 return variant === LanguageVariant.LDMud;
             default:
                 return true;

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -889,6 +889,13 @@ Found 1 error in server/src/tests/cases/compiler/variantKeywordBufferLdmudMisuse
 "
 `;
 
+exports[`Compiler compiler/variantKeywordBytesFluffosMisuse.c Reports correct errors for compiler/variantKeywordBytesFluffosMisuse.c: diags-compiler/variantKeywordBytesFluffosMisuse.c 1`] = `
+"
+Found 1 error in server/src/tests/cases/compiler/variantKeywordBytesFluffosMisuse.c[90m:6[0m
+
+"
+`;
+
 exports[`Compiler compiler/variantKeywordClassLdmudMisuse.c Reports correct errors for compiler/variantKeywordClassLdmudMisuse.c: diags-compiler/variantKeywordClassLdmudMisuse.c 1`] = `
 "
 Found 1 error in server/src/tests/cases/compiler/variantKeywordClassLdmudMisuse.c[90m:5[0m
@@ -896,9 +903,37 @@ Found 1 error in server/src/tests/cases/compiler/variantKeywordClassLdmudMisuse.
 "
 `;
 
+exports[`Compiler compiler/variantKeywordClosureFluffosMisuse.c Reports correct errors for compiler/variantKeywordClosureFluffosMisuse.c: diags-compiler/variantKeywordClosureFluffosMisuse.c 1`] = `
+"
+Found 1 error in server/src/tests/cases/compiler/variantKeywordClosureFluffosMisuse.c[90m:7[0m
+
+"
+`;
+
+exports[`Compiler compiler/variantKeywordDeprecatedFluffosMisuse.c Reports correct errors for compiler/variantKeywordDeprecatedFluffosMisuse.c: diags-compiler/variantKeywordDeprecatedFluffosMisuse.c 1`] = `
+"
+Found 2 errors in the same file, starting at: server/src/tests/cases/compiler/variantKeywordDeprecatedFluffosMisuse.c[90m:6[0m
+
+"
+`;
+
+exports[`Compiler compiler/variantKeywordLwobjectFluffosMisuse.c Reports correct errors for compiler/variantKeywordLwobjectFluffosMisuse.c: diags-compiler/variantKeywordLwobjectFluffosMisuse.c 1`] = `
+"
+Found 1 error in server/src/tests/cases/compiler/variantKeywordLwobjectFluffosMisuse.c[90m:6[0m
+
+"
+`;
+
 exports[`Compiler compiler/variantKeywordStatusFluffosMisuse.c Reports correct errors for compiler/variantKeywordStatusFluffosMisuse.c: diags-compiler/variantKeywordStatusFluffosMisuse.c 1`] = `
 "
 Found 1 error in server/src/tests/cases/compiler/variantKeywordStatusFluffosMisuse.c[90m:5[0m
+
+"
+`;
+
+exports[`Compiler compiler/variantKeywordVirtualFluffosMisuse.c Reports correct errors for compiler/variantKeywordVirtualFluffosMisuse.c: diags-compiler/variantKeywordVirtualFluffosMisuse.c 1`] = `
+"
+Found 2 errors in the same file, starting at: server/src/tests/cases/compiler/variantKeywordVirtualFluffosMisuse.c[90m:6[0m
 
 "
 `;

--- a/server/src/tests/__snapshots__/compiler.spec.ts.snap
+++ b/server/src/tests/__snapshots__/compiler.spec.ts.snap
@@ -696,6 +696,8 @@ Found 1 error in server/src/tests/cases/compiler/new6.c[90m:11[0m
 "
 `;
 
+exports[`Compiler compiler/new7.c Reports correct errors for compiler/new7.c: diags-compiler/new7.c 1`] = `""`;
+
 exports[`Compiler compiler/nullishCoalescing.c Reports correct errors for compiler/nullishCoalescing.c: diags-compiler/nullishCoalescing.c 1`] = `""`;
 
 exports[`Compiler compiler/nullishCoalescingLdmud.c Reports correct errors for compiler/nullishCoalescingLdmud.c: diags-compiler/nullishCoalescingLdmud.c 1`] = `

--- a/server/src/tests/cases/compiler/new7.c
+++ b/server/src/tests/cases/compiler/new7.c
@@ -1,0 +1,26 @@
+// FluffOS maps both spellings to the same token: lexer_utils.cc's reswords[] has
+// {"class", L_CLASS, 0} and {"struct", L_CLASS, 0}, both under #defines that are
+// unconditional in options_internal.h. So `new(struct Foo)` is the same grammar
+// production as `new(class Foo)` -- `L_NEW '(' L_CLASS ...` -- and the two
+// spellings interchange freely.
+
+struct Foo {
+    int bar;
+}
+
+test() {
+    struct Foo a;
+    a = new(struct Foo);
+    a.bar = 1;
+
+    // declared with one spelling, constructed with the other
+    class Foo b = new(class Foo);
+    b.bar = 2;
+
+    // named arguments work either way
+    struct Foo c = new(struct Foo, bar: 3);
+    c.bar = 4;
+}
+
+// @driver: fluffos
+// @errors: 0

--- a/server/src/tests/cases/compiler/variantKeywordBytesFluffosMisuse.c
+++ b/server/src/tests/cases/compiler/variantKeywordBytesFluffosMisuse.c
@@ -1,0 +1,10 @@
+// Mirror of variantKeywordsLdmud.c: `bytes` is NOT a type under FluffOS (which
+// spells the byte buffer `buffer`), so using it as a parameter type is rejected --
+// it scans as an identifier, so `bytes b` reads as two adjacent identifiers.
+// Guards that the demotion actually happens.
+
+void f(bytes b) {
+}
+
+// @driver: fluffos
+// @errors: 1

--- a/server/src/tests/cases/compiler/variantKeywordClosureFluffosMisuse.c
+++ b/server/src/tests/cases/compiler/variantKeywordClosureFluffosMisuse.c
@@ -1,0 +1,11 @@
+// Mirror of variantKeywordsLdmud.c: `closure` is NOT a type under FluffOS, which
+// has no closures at all -- its `(: :)` is a functional, and the driver refuses a
+// local variable inside one. Using `closure` as a parameter type is rejected: it
+// scans as an identifier, so `closure c` reads as two adjacent identifiers.
+// Guards that the demotion actually happens.
+
+void f(closure c) {
+}
+
+// @driver: fluffos
+// @errors: 1

--- a/server/src/tests/cases/compiler/variantKeywordDeprecatedFluffosMisuse.c
+++ b/server/src/tests/cases/compiler/variantKeywordDeprecatedFluffosMisuse.c
@@ -1,0 +1,9 @@
+// Mirror of variantKeywordsLdmud.c: `deprecated` is a type modifier only under
+// LDMud (L_DEPRECATED -> TYPE_MOD_DEPRECATED). Under FluffOS it scans as an
+// identifier, so this reads as an expression statement followed by a declaration
+// rather than a modified function. Guards that the demotion actually happens.
+
+deprecated int foo() { return 1; }
+
+// @driver: fluffos
+// @errors: 2

--- a/server/src/tests/cases/compiler/variantKeywordLwobjectFluffosMisuse.c
+++ b/server/src/tests/cases/compiler/variantKeywordLwobjectFluffosMisuse.c
@@ -1,0 +1,10 @@
+// Mirror of variantKeywordsLdmud.c: `lwobject` is NOT a type under FluffOS, which
+// has no lightweight objects, so using it as a parameter type is rejected -- it
+// scans as an identifier, so `lwobject o` reads as two adjacent identifiers.
+// Guards that the demotion actually happens.
+
+void f(lwobject o) {
+}
+
+// @driver: fluffos
+// @errors: 1

--- a/server/src/tests/cases/compiler/variantKeywordVirtualFluffosMisuse.c
+++ b/server/src/tests/cases/compiler/variantKeywordVirtualFluffosMisuse.c
@@ -1,0 +1,9 @@
+// Mirror of variantKeywordsLdmud.c: `virtual` is a type modifier only under LDMud
+// (L_VIRTUAL -> TYPE_MOD_VIRTUAL). Under FluffOS it scans as an identifier, so
+// this reads as an expression statement followed by a declaration rather than a
+// modified function. Guards that the demotion actually happens.
+
+virtual int foo() { return 1; }
+
+// @driver: fluffos
+// @errors: 2

--- a/server/src/tests/cases/compiler/variantKeywordsFluffos.c
+++ b/server/src/tests/cases/compiler/variantKeywordsFluffos.c
@@ -1,6 +1,7 @@
 // Driver-specific type keywords, FluffOS side (see PR #331 discussion):
 //   - `buffer` and `class` are real types (LDMud uses `struct` for structures)
-//   - `status` / `symbol` are NOT keywords here, so they are ordinary identifiers
+//   - `bytes` / `closure` / `deprecated` / `lwobject` / `status` / `symbol` / `virtual`
+//     are NOT keywords here, so they are ordinary identifiers
 // The scanner decides this per driver, so the AST is uniform and no parser gate
 // is needed.
 
@@ -35,12 +36,31 @@ void call_it() {
     modifies(&a);
 }
 
+// LDMud's type names (`bytes`, `closure`, `lwobject`) and modifiers (`deprecated`,
+// `virtual`) have no counterpart in FluffOS, so the words are free to be function
+// names here
+int bytes() { return 7; }
+int closure() { return 8; }
+int deprecated() { return 9; }
+int lwobject() { return 10; }
+int virtual() { return 11; }
+
 void f() {
-    // status / symbol are just identifiers under FluffOS
+    // ...and variable names -- all just identifiers under FluffOS
+    int bytes;
+    int closure;
+    int deprecated;
+    int lwobject;
     int status;
     int symbol;
+    int virtual;
+    bytes = 3;
+    closure = 4;
+    deprecated = 5;
+    lwobject = 6;
     status = 1;
     symbol = 2;
+    virtual = 7;
 }
 
 // @driver: fluffos

--- a/server/src/tests/cases/compiler/variantKeywordsLdmud.c
+++ b/server/src/tests/cases/compiler/variantKeywordsLdmud.c
@@ -1,5 +1,6 @@
 // Driver-specific type keywords, LDMud side (see PR #331 discussion):
-//   - `status` / `symbol` are real types
+//   - `bytes` / `closure` / `lwobject` / `status` / `symbol` are real types, and
+//     `deprecated` / `virtual` are real modifiers
 //   - `buffer` is NOT a keyword here, so it is an ordinary identifier
 // The scanner decides this per driver, so the AST is uniform and no parser gate
 // is needed.
@@ -13,6 +14,32 @@ symbol make_symbol() {
     symbol y;
     return y;
 }
+
+// `bytes` is LDMud's byte-string type, distinct from the unicode `string`
+bytes make_bytes() {
+    bytes data;
+    return data;
+}
+
+void takes_bytes(bytes data) {
+}
+
+// `closure` and `lwobject` are LDMud types with no FluffOS counterpart (FluffOS
+// spells closures `function` and has no lightweight objects)
+closure make_closure() {
+    closure cl;
+    return cl;
+}
+
+lwobject make_lwobject() {
+    lwobject lw;
+    return lw;
+}
+
+// `deprecated` and `virtual` are LDMud type modifiers
+deprecated int old_api() { return 1; }
+
+private deprecated int legacy = 1;
 
 // `buffer`, `class`, `new` and `ref` are just identifiers under LDMud -- usable as
 // function names (LDMud constructs objects with clone_object() and marks by-reference

--- a/server/src/tests/predicateNarrowing.spec.ts
+++ b/server/src/tests/predicateNarrowing.spec.ts
@@ -8,9 +8,10 @@ import * as path from "path";
  * inside the branch reported a spurious assignability error.
  *
  * Not every `*p()` is a type test: `clonep` and `referencep` (LDMud) ask about
- * an object's origin and how an argument was passed, and `classp` (FluffOS)
- * tests T_CLASS with no single type to narrow to. Those deliberately carry no
- * predicate.
+ * an object's origin and how an argument was passed, not its type. `classp`
+ * (FluffOS) is a type test, but an unwritable one -- it asks "is this any
+ * class?", and a class type always carries a name, so there is nothing to put
+ * after `arg is`. All three deliberately carry no predicate.
  */
 
 function messages(source: string, driverType: lpc.LanguageVariant): string {
@@ -70,8 +71,13 @@ describe("*p() guard narrowing", () => {
         });
 
         it("does not narrow on classp, which is not a single-type test", () => {
-            // classp() tests T_CLASS. There is no one type to narrow to, so it
-            // deliberately carries no predicate -- the error must survive.
+            // Not because `class` isn't a real type -- `@returns {arg is class coord}`
+            // narrows fine. It is that classp() asks "is this ANY class?", and there
+            // is no bare `class` type to name as the target: FluffOS's grammar has
+            // only `L_CLASS <name>`, and StructTypeNode requires an Identifier.
+            // pointerp() faces the same "any array" question and escapes it only
+            // because `mixed *` is a real writable supertype. So classp() carries no
+            // predicate and the error must survive.
             expect(messages(`void test(mapping | int m) { if (classp(m)) { mapping x = m; } }`, fluffos))
                 .toContain("is not assignable to type 'mapping'");
         });

--- a/server/src/tests/predicateNarrowing.spec.ts
+++ b/server/src/tests/predicateNarrowing.spec.ts
@@ -1,0 +1,104 @@
+import * as lpc from "./_namespaces/lpc.js";
+import * as path from "path";
+
+/**
+ * The `*p()` guard efuns narrow a union in the branch they guard, but only when
+ * their stub carries a `@returns {arg is T}` type predicate. Several stubs were
+ * missing one, so `if (mapp(m))` left `m` at its declared union and every use
+ * inside the branch reported a spurious assignability error.
+ *
+ * Not every `*p()` is a type test: `clonep` and `referencep` (LDMud) ask about
+ * an object's origin and how an argument was passed, and `classp` (FluffOS)
+ * tests T_CLASS with no single type to narrow to. Those deliberately carry no
+ * predicate.
+ */
+
+function messages(source: string, driverType: lpc.LanguageVariant): string {
+    const root = process.cwd();
+    const virtualFile = lpc.normalizeSlashes(path.join(root, "server/src/tests/cases/compiler/__predicateProbe.c"));
+    const isVirtual = (fn: string) => !!fn && lpc.normalizeSlashes(fn) === virtualFile;
+
+    const compilerOptions: lpc.CompilerOptions = { driverType, diagnostics: true };
+    const host = lpc.createCompilerHost(compilerOptions);
+    const origReadFile = host.readFile;
+    const origFileExists = host.fileExists;
+    host.readFile = (fn: string) => (isVirtual(fn) ? source : origReadFile.call(host, fn));
+    host.fileExists = (fn: string) => (isVirtual(fn) ? true : origFileExists.call(host, fn));
+    host.getDefaultLibFileName = () =>
+        lpc.combinePaths(root, lpc.getDefaultLibFolder(compilerOptions), lpc.getDefaultLibFileName(compilerOptions));
+
+    const program = lpc.createProgram({ host, rootNames: [virtualFile], options: compilerOptions, oldProgram: undefined });
+    const file = program.getSourceFile(virtualFile)!;
+    return [...file.parseDiagnostics, ...program.getSemanticDiagnostics(file)]
+        .map(d => lpc.flattenDiagnosticMessageText(d.messageText, "\n")).join("\n");
+}
+
+/**
+ * A union parameter is the only shape that detects this: `mixed` is assignable
+ * to anything, so a `mixed` probe passes whether or not narrowing happened.
+ */
+function guards(guard: string, type: string, other: string, driverType: lpc.LanguageVariant): string {
+    return messages(`void test(${type} | ${other} m) { if (${guard}(m)) { ${type} narrowed = m; } }`, driverType);
+}
+
+describe("*p() guard narrowing", () => {
+    describe("FluffOS", () => {
+        const fluffos = lpc.LanguageVariant.FluffOS;
+
+        it.each([
+            ["stringp", "string", "int"],
+            ["objectp", "object", "int"],
+            ["pointerp", "mixed *", "int"],
+            ["arrayp", "mixed *", "int"],
+            ["functionp", "function", "int"],
+            ["mapp", "mapping", "int"],
+            ["intp", "int", "string"],
+            ["bufferp", "buffer", "int"],
+            ["floatp", "float", "string"],
+        ])("%s narrows to %s", (guard, type, other) => {
+            expect(guards(guard, type, other, fluffos)).toBe("");
+        });
+
+        it("narrows in the else branch too", () => {
+            expect(messages(`void test(mapping | int m) { if (mapp(m)) { mapping x = m; } else { int n = m; } }`, fluffos)).toBe("");
+        });
+
+        it("nullp and undefinedp are the same efun and narrow alike", () => {
+            // core.spec:144 declares `int nullp undefinedp(mixed);` -- one efun, two names.
+            expect(messages(`void test(string m) { if (nullp(m)) { int n = m; } }`, fluffos)).toBe("");
+            expect(messages(`void test(string m) { if (undefinedp(m)) { int n = m; } }`, fluffos)).toBe("");
+        });
+
+        it("still reports the error when the guard does not cover the use", () => {
+            // The narrowing must be real, not a blanket suppression: an `intp` guard
+            // says nothing about the string constituent.
+            expect(messages(`void test(mapping | int m) { if (intp(m)) { mapping x = m; } }`, fluffos))
+                .toContain("is not assignable to type 'mapping'");
+        });
+    });
+
+    describe("LDMud", () => {
+        const ldmud = lpc.LanguageVariant.LDMud;
+
+        it.each([
+            ["stringp", "string", "int"],
+            ["objectp", "object", "int"],
+            ["pointerp", "mixed *", "int"],
+            ["mappingp", "mapping", "int"],
+            ["intp", "int", "string"],
+            ["floatp", "float", "string"],
+            // `symbolp` carries its predicate, but this row cannot currently fail.
+            // `symbol` has no case in getTypeFromTypeNodeWorker(), so it falls to
+            // the default branch ("Implement me - getTypeFromTypeNodeWorker
+            // SymbolKeyword") and resolves to errorType, which is assignable in
+            // both directions -- there is no error for narrowing to remove. Kept
+            // so the row starts working once `symbol` is given a real type.
+            ["symbolp", "symbol", "int"],
+            ["lwobjectp", "lwobject", "int"],
+            ["closurep", "closure", "int"],
+            ["bytesp", "bytes", "int"],
+        ])("%s narrows to %s", (guard, type, other) => {
+            expect(guards(guard, type, other, ldmud)).toBe("");
+        });
+    });
+});

--- a/server/src/tests/predicateNarrowing.spec.ts
+++ b/server/src/tests/predicateNarrowing.spec.ts
@@ -69,6 +69,13 @@ describe("*p() guard narrowing", () => {
             expect(messages(`void test(string m) { if (undefinedp(m)) { int n = m; } }`, fluffos)).toBe("");
         });
 
+        it("does not narrow on classp, which is not a single-type test", () => {
+            // classp() tests T_CLASS. There is no one type to narrow to, so it
+            // deliberately carries no predicate -- the error must survive.
+            expect(messages(`void test(mapping | int m) { if (classp(m)) { mapping x = m; } }`, fluffos))
+                .toContain("is not assignable to type 'mapping'");
+        });
+
         it("still reports the error when the guard does not cover the use", () => {
             // The narrowing must be real, not a blanket suppression: an `intp` guard
             // says nothing about the string constituent.
@@ -99,6 +106,17 @@ describe("*p() guard narrowing", () => {
             ["bytesp", "bytes", "int"],
         ])("%s narrows to %s", (guard, type, other) => {
             expect(guards(guard, type, other, ldmud)).toBe("");
+        });
+
+        it.each([
+            // Neither asks about type: clonep() distinguishes a clone from its
+            // blueprint, referencep() reports how an argument was passed. Both
+            // deliberately carry no predicate, so the error must survive.
+            ["clonep"],
+            ["referencep"],
+        ])("%s does not narrow", guard => {
+            expect(messages(`void test(mapping | int m) { if (${guard}(m)) { mapping x = m; } }`, ldmud))
+                .toContain("is not assignable to type 'mapping'");
         });
     });
 });


### PR DESCRIPTION
Two independent FluffOS defects, each verified against the drivers' own authoritative tables rather than their docs.

## 1. LDMud-only reserved words leaked into FluffOS

`bytes`, `closure`, `lwobject`, `deprecated` and `virtual` were keywords in **both** drivers, so a FluffOS mudlib using any of them as an ordinary name got a spurious diagnostic. None exists in FluffOS:

| word | LDMud (`src/lex.c` `reswords[]`) | FluffOS (`src/compiler/internal/lexer_utils.cc`) |
|---|---|---|
| `bytes` | `L_BYTES_DECL` | absent |
| `closure` | `L_CLOSURE_DECL` | absent |
| `lwobject` | `L_LWOBJECT` | absent |
| `deprecated` | `L_DEPRECATED` → `TYPE_MOD_DEPRECATED` | absent |
| `virtual` | `L_VIRTUAL` → `TYPE_MOD_VIRTUAL` | absent |

`isKeywordInVariant()` already existed for exactly this — these five simply fell through `default: return true`.

Gating `closure` exposed a FluffOS efun stub that had borrowed LDMud's type name: `resolve()`'s second overload declared `closure callback_func`, but `core.spec:347` says `int resolve(string, string | function);`. FluffOS has no closure type at all — its `(: :)` is a *functional*, and the compiler rejects a local variable inside one (`grammar_rules_types.cc:51`). Corrected to `function` in `interactive.h` and its zh-cn mirror.

## 2. Several `*p()` guards did not narrow

Narrowing is driven entirely by a `@returns {arg is T}` annotation on the guard's stub. `stringp`, `objectp`, `pointerp`, `arrayp` and `functionp` had one; these did not:

- **FluffOS** — `mapp`, `intp`, `bufferp`, `floatp`, `undefinedp`
- **LDMud** — `symbolp`, `lwobjectp`, `closurep`, `bytesp`

So `if (mapp(m))` left `m` at its declared union and every use inside the branch reported a spurious assignability error. On a real mudlib that is ~110 guard sites for the FluffOS four alone.

`undefinedp` takes `nullp`'s predicate verbatim — `core.spec:144` declares `int nullp undefinedp(mixed);`, one efun under two names, so the same guard narrowed or didn't depending on which name you typed. `closurep` spells its predicate `{c is closure}` because its parameter is named `c`.

**Three `*p()` efuns deliberately get no predicate**, and now have tests saying so. `clonep` and `referencep` (LDMud) ask about an object's origin and how an argument was passed, not its type.

`classp` (FluffOS) is subtler and worth spelling out, since "class isn't narrowable" is the wrong reading. A *named*-class predicate narrows fine — `@returns {arg is class coord}` against a `class coord | int` union produces zero diagnostics. The obstacle is that `classp` asks "is this **any** class?", and a class type always carries a name: FluffOS's grammar has only `L_CLASS L_DEFINED_NAME` / `L_CLASS L_IDENTIFIER`, with no bare-`class` production, and `StructTypeNode` requires an `Identifier` to match. There is nothing to write after `arg is`. `pointerp` asks the same "any array" question and escapes it only because `mixed *` is a real writable supertype every array is assignable to; classes have no equivalent. Fixable with a synthetic "any class" supertype in the checker — which is also what `typeof(x) == "class"` narrowing would need, so it belongs with that work rather than here.

## 3. `new(struct Foo)` did not parse

FluffOS registers `class` and `struct` as **the same token** — `lexer_utils.cc`'s `reswords[]` has `{"class", L_CLASS, 0}` and `{"struct", L_CLASS, 0}`, and both `STRUCT_CLASS` and `STRUCT_STRUCT` are unconditional `#define`s in `options_internal.h`, so this isn't build-dependent. The grammar production is `L_NEW '(' L_CLASS ...`, making `new(struct Foo)` exactly `new(class Foo)`.

`parseNewExpression()` tested only for `ClassKeyword`, so `struct` fell through to the argument-list branch and produced two parse errors on valid code (`Argument expression expected.`, `';' expected.`).

Everything downstream already handled the duality — `StructKeywordSyntaxKind` is `StructKeyword | ClassKeyword` and `parseStructTypeNode()` takes the keyword as a parameter — so only the guard needed widening. `new` is FluffOS-only per `isKeywordInVariant`, so accepting either spelling needs no driver gate of its own.

## Tests

`35 suites / 1115 tests`, 6 new snapshots.

- Both `variantKeywords*.c` fixtures extended to all five words — as function and variable names on the FluffOS side, as types and modifiers on the LDMud side.
- Five new `variantKeyword*Misuse.c` fixtures following the existing `buffer`/`class`/`status` pattern: using each word as a type in the wrong driver must be *rejected*, which is the strong form of the demotion guard.
- New `new7.c` covers construction with each spelling, declaring with one and constructing with the other, and the named-argument form. Reverting the parser change fails it.
- New `predicateNarrowing.spec.ts`, 25 cases across both drivers. It probes with a **union** parameter rather than `mixed` — `mixed` is assignable to everything, so a `mixed` probe would pass whether or not narrowing happened — and includes negative cases so the fix cannot degrade into blanket suppression. Reverting just the efun changes fails 9 rows.

## Note

One test row is honest ballast. `symbolp` carries its predicate but cannot currently fail: `symbol` has no case in `getTypeFromTypeNodeWorker()`, so it falls to the default branch (`Implement me - getTypeFromTypeNodeWorker SymbolKeyword`) and resolves to `errorType`, which is assignable in both directions — there is no error for narrowing to remove. The row is commented and kept so it starts working once `symbol` is given a real type. That gap pre-exists this branch, along with `UndefinedKeyword`, `MappingType` and `JSDocReturnTag`; none are touched here.
