### PR TITLE
Highlight FluffOS mapping dot-access and optional-chaining keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: Hover provider - show a declaration's modifiers- #366
 - Fix: FluffOS keyword gating, \*p() narrowing predicates, and new(struct Foo)- #368
 - Update to TypeScript 7, switch ts-jest to @swc/jest
+- Fix: FluffOS mapping dot-access and optional-chaining keys (`m.key`, `m?.a?.b`) were left unhighlighted
 
 ## 1.1.54
 

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -373,6 +373,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         getMergedSymbol,
         getAllPossiblePropertiesOfTypes,
         isArrayLikeType,
+        isMappingType,
         isNullableType,
         getNullableType,
         getNonNullableType,

--- a/server/src/compiler/types.ts
+++ b/server/src/compiler/types.ts
@@ -117,6 +117,11 @@ export interface TypeChecker {
      */
     isArrayLikeType(type: Type): boolean;
     /**
+     * True if this type is a mapping. Used by the semantic classifier to
+     * recognise FluffOS mapping dot-access keys, which bind to no symbol.
+     */
+    isMappingType(type: Type): boolean;
+    /**
      * True if `contextualType` should not be considered for completions because
      * e.g. it specifies `kind: "a"` and obj has `kind: "b"`.
      *

--- a/server/src/services/classifier2020.ts
+++ b/server/src/services/classifier2020.ts
@@ -22,11 +22,14 @@ import {
     isQualifiedName,
     isSourceFile,
     isVariableDeclaration,
+    LanguageVariant,
     ModifierFlags,
     NamedDeclaration,
     Node,
+    NodeFlags,
     ParameterDeclaration,
     Program,
+    PropertyAccessExpression,
     SemanticMeaning,
     SourceFile,
     Symbol,
@@ -212,6 +215,15 @@ function collectTokens(program: Program, sourceFile: SourceFile, span: TextSpan,
                     }
                 }
             }
+            else if (isFluffOSMappingKey(typeChecker, sourceFile, node) && isFromFile(node)) {
+                // FluffOS mapping dot-access (`m.key`, `m?.key`) is sugar for `m["key"]`,
+                // so the checker resolves it through indexed access with no property
+                // symbol (see checkPropertyAccessExpressionOrQualifiedName). Without a
+                // symbol the branch above emits nothing and the key renders unstyled, as
+                // the grammar has no rule for bare identifiers either. Classify it as a
+                // property so it reads like the member access it stands in for.
+                collector(node, reclassifyByType(typeChecker, node, TokenType.property), 0);
+            }
         }
         
         forEachChild(node, visit);        
@@ -298,6 +310,52 @@ function isExpressionInCallExpression(node: Node): boolean {
         node = node.parent;
     }
     return isCallExpression(node.parent) && node.parent.expression === node;
+}
+
+/**
+ * True for the key of a FluffOS mapping dot-access - the `key` of `m.key` or `m?.key`.
+ *
+ * Gated to FluffOS: LDMud has neither mapping dot-access nor optional chaining, so
+ * there the same syntax is an error and must not be painted as a resolved property.
+ */
+function isFluffOSMappingKey(typeChecker: TypeChecker, sourceFile: SourceFile, node: Node): boolean {
+    if (sourceFile.languageVariant !== LanguageVariant.FluffOS) {
+        return false;
+    }
+    const parent = node.parent;
+    return !!parent && isPropertyAccessExpression(parent) && parent.name === node
+        && isMappingAccessChain(typeChecker, parent);
+}
+
+/**
+ * True when `access` is a link in a chain of mapping key accesses.
+ *
+ * Only the root of such a chain types as a mapping: the checker resolves each key
+ * through indexed access, so `m.a` is `mixed`, and asking whether the *immediate*
+ * base is a mapping would classify only the first key of `m.a.b.c`. But a key can
+ * only be dot-accessed in turn if it holds a mapping, so every non-terminal link is
+ * a mapping by construction - walk back to the root and test that instead.
+ *
+ * An optional link short-circuits the walk: `?.` is mapping-only by construction, so
+ * reaching one is already proof of intent (and `m?.a?.b` is legal even when `m.a`
+ * turns out not to be a mapping, since the chain yields undefined rather than erroring).
+ *
+ * `->` is excluded throughout - that is object member access, not a mapping key, and
+ * a chain may mix the two (`m.a->func`).
+ */
+function isMappingAccessChain(typeChecker: TypeChecker, access: PropertyAccessExpression): boolean {
+    if (access.propertyAccessToken.kind === SyntaxKind.MinusGreaterThanToken) {
+        return false;
+    }
+    if (access.flags & NodeFlags.OptionalChain) {
+        return true;
+    }
+    const base = access.expression;
+    if (isPropertyAccessExpression(base)) {
+        return isMappingAccessChain(typeChecker, base);
+    }
+    const baseType = typeChecker.getTypeAtLocation(base);
+    return !!baseType && typeChecker.isMappingType(baseType);
 }
 
 function isRightSideOfQualifiedNameOrPropertyAccess(node: Node): boolean {

--- a/server/src/tests/optionalChaining.spec.ts
+++ b/server/src/tests/optionalChaining.spec.ts
@@ -1,4 +1,5 @@
 import * as lpc from "./_namespaces/lpc.js";
+import { createTestLanguageService } from "./harness.js";
 import * as path from "path";
 
 /**
@@ -151,6 +152,75 @@ describe("Mapping dot-access & optional chaining", () => {
             // The left-hand side of an assignment may not be an optional property access.
             expect(diags.length).toBeGreaterThan(0);
             expect(diags.some(d => typeof d.messageText === "string" && /optional/i.test(d.messageText))).toBe(true);
+        });
+    });
+
+    describe("semantic classification", () => {
+        /**
+         * TokenType/TokenModifier are packed as `(type + 1) << 8 | modifiers`
+         * (TokenEncodingConsts), matching what the client decodes in
+         * `client/src/languageFeatures/semanticTokens.ts`.
+         */
+        const TOKEN_TYPE_PROPERTY = 9;
+
+        /** Classification emitted for `name`, or undefined if the server emitted none. */
+        function classify(source: string, name: string, driverType = lpc.LanguageVariant.FluffOS): number | undefined {
+            const { ls, fileName } = createTestLanguageService({ "test.c": source }, { driverType });
+            const { spans } = ls.getEncodedSemanticClassifications(fileName, lpc.createTextSpan(0, source.length));
+            // Anchor on the accessor (`.`, `?.` or `->`): a bare indexOf would find a
+            // short key inside an earlier word (the "a" of "mapping", say).
+            const at = new RegExp(`[.>]\\s*${name}\\b`).exec(source);
+            expect(at).not.toBeNull();
+            const offset = at!.index + at![0].length - name.length;
+            for (let i = 0; i < spans.length; i += 3) {
+                if (spans[i] === offset && spans[i + 1] === name.length) {
+                    return (spans[i + 2] >> 8) - 1;
+                }
+            }
+            return undefined;
+        }
+
+        it("classifies a mapping dot-access key as a property", () => {
+            expect(classify("void f() { mapping m = ([]); mixed r = m.key; }", "key")).toBe(TOKEN_TYPE_PROPERTY);
+        });
+
+        it("classifies an optional-chain key as a property", () => {
+            expect(classify("void f() { mapping m = ([]); mixed r = m?.key; }", "key")).toBe(TOKEN_TYPE_PROPERTY);
+        });
+
+        it("classifies every key of a nested optional chain", () => {
+            const src = "void f() { mapping m = ([]); mixed r = m?.a?.b; }";
+            expect(classify(src, "a")).toBe(TOKEN_TYPE_PROPERTY);
+            expect(classify(src, "b")).toBe(TOKEN_TYPE_PROPERTY);
+        });
+
+        it("classifies every key of a plain dot chain", () => {
+            // Only the root types as a mapping -- `m.a` is mixed -- so this only works
+            // by walking back to the root rather than testing the immediate base.
+            const src = "void f() { mapping m = ([]); mixed r = m.a.b.c; }";
+            expect(classify(src, "a")).toBe(TOKEN_TYPE_PROPERTY);
+            expect(classify(src, "b")).toBe(TOKEN_TYPE_PROPERTY);
+            expect(classify(src, "c")).toBe(TOKEN_TYPE_PROPERTY);
+        });
+
+        it("classifies chains that mix optional and plain links", () => {
+            const a = "void f() { mapping m = ([]); mixed r = m?.a.b; }";
+            expect(classify(a, "b")).toBe(TOKEN_TYPE_PROPERTY);
+            const b = "void f() { mapping m = ([]); mixed r = m.a?.b; }";
+            expect(classify(b, "b")).toBe(TOKEN_TYPE_PROPERTY);
+        });
+
+        it("does not treat an arrow link as a mapping key", () => {
+            // `->` is object member access, and a chain may mix the two.
+            expect(classify("void f() { mapping m = ([]); mixed r = m.a->func; }", "func")).toBeUndefined();
+        });
+
+        it("does not classify a mapping key under LDMud, where the syntax is an error", () => {
+            expect(classify("void f() { mapping m = ([]); mixed r = m.key; }", "key", lpc.LanguageVariant.LDMud)).toBeUndefined();
+        });
+
+        it("leaves a non-mapping base alone", () => {
+            expect(classify("void f() { int n = 1; mixed r = n.key; }", "key")).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
## Summary

Mapping dot-access (`m.key`) and optional chaining (`m?.key`) left their **key names** completely unstyled in the editor. The `?.` operator itself was already scoped by #323 — only the keys were bare.

Neither highlighting layer had anything to say about them:

- **Semantic tokens.** Mapping dot-access is sugar for `m["key"]`, so the checker resolves it through indexed access with `/*prop*/ undefined` (`checker.ts`, `checkPropertyAccessExpressionOrQualifiedName`). No symbol means `classifier2020` emits no token.
- **TextMate.** The grammar scopes the access *operator* but has no rule for bare identifiers, so the key falls through to the enclosing `meta.*` scopes only.

The VS Code scope inspector on such a key shows just `meta.parens` / `meta.block` / `meta.function` / `source.lpc.lang-server`, "No theme selector", and no semantic-token row at all.

## Approach

Classify a mapping key as `property` on the classifier's no-symbol path. `property` is already in the client's semantic-tokens legend and maps to VS Code's standard `property` type, so themes pick it up with no client change.

The non-obvious part is which accesses qualify. Only the **root** of a chain types as a mapping — `m.a` is `mixed` — so testing the immediate base classifies just the first key of `m.a.b.c`. But a key can only be dot-accessed *in turn* if it holds a mapping, so every non-terminal link is a mapping by construction; `isMappingAccessChain` walks back to the root instead.

- `->` is excluded from the walk — that's object member access, and a chain may mix the two (`m.a->func`).
- `?.` short-circuits the walk: it is mapping-only by construction, and `m?.a?.b` is legal even when `m.a` isn't a mapping, since the chain yields undefined rather than erroring. Sound for colouring; deliberately **not** used as type narrowing.

Gated to FluffOS, mirroring the checker's own gate. LDMud has neither mapping dot-access nor optional chaining, so there the same syntax is an error and must not be painted as a resolved property.

## User-visible change

Mapping keys now take the theme's `property` colour instead of the default foreground, for both `m.key` and `m?.key`, at every depth of a chain. No diagnostics, inference, or completion behaviour changes.

## Notes

`isMappingType` is exposed on the `TypeChecker` interface (alongside the existing `isArrayLikeType`) so the classifier can ask the question.

Keys still carry no symbol, so hover and go-to-definition on them are unchanged — a mapping type is `__LS__Mapping<K, V>`, a homogeneous key→value signature with no per-key member list, so there is nothing to bind to. `struct` remains the way to get named members with real symbols.

## Tests

`server/src/tests/optionalChaining.spec.ts` gains classification coverage: plain and optional keys, nested optional chains, plain dot chains (`m.a.b.c`), chains mixing both accessors, the `->` exclusion, a non-mapping base, and the LDMud gate.

Full suite green — 1123 tests, 293 snapshots, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DGBDUhBwKX9rwp8bLCG9p