### PR TITLE
throw() ends control flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: Hover provider - show a declaration's modifiers- #366
 - Fix: FluffOS keyword gating, \*p() narrowing predicates, and new(struct Foo)- #368
 - Update to TypeScript 7, switch ts-jest to @swc/jest
+- Fix: `throw()` now ends control flow, so a function whose body only throws no longer reports a missing return
 
 ## 1.1.54
 

--- a/server/src/compiler/binder.ts
+++ b/server/src/compiler/binder.ts
@@ -2147,11 +2147,30 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         }
     }
 
-    function isErrorCallExpression(node: CallExpression) {        
-        // error() for Fluff
-        // raise_error() for LD
-        // Fluff has throw too, but it doesn't terminate execution.                
-        return isIdentifier(node.expression) && node.expression.text === (file.languageVariant === LanguageVariant.FluffOS ? "error" : "raise_error");
+    /**
+     * Calls that never return, so the code after them is unreachable.
+     *
+     * `throw()` counts under both drivers. In FluffOS it is declared `void` in core.spec
+     * and reaches the same `[[noreturn]] throw_error()` (simulate.cc) that `error()` does;
+     * LDMud documents its own `void throw(mixed)` as "Abort execution". Either way a
+     * `catch()` resumes after the catch, never after the call.
+     *
+     * `throw()` was previously excluded on the grounds that it "doesn't terminate
+     * execution", which matches neither driver. Leaving it out made any non-void function
+     * whose body only throws draw a spurious "must return a value" -- and in FluffOS that
+     * shape is the driver's own idiom for rejecting an async result, since throw_error()
+     * documents a value thrown inside an async body as becoming the rejection reason /
+     * acatch() result.
+     */
+    function isErrorCallExpression(node: CallExpression) {
+        if (!isIdentifier(node.expression)) {
+            return false;
+        }
+        const name = node.expression.text;
+        if (name === "throw") {
+            return true;
+        }
+        return name === (file.languageVariant === LanguageVariant.FluffOS ? "error" : "raise_error");
     }
 
     function bindLogicalLikeExpression(node: BinaryExpression, trueTarget: FlowLabel, falseTarget: FlowLabel) {

--- a/server/src/tests/throwTerminatesFlow.spec.ts
+++ b/server/src/tests/throwTerminatesFlow.spec.ts
@@ -1,0 +1,77 @@
+import * as lpc from "./_namespaces/lpc.js";
+import { createTestLanguageService } from "./harness.js";
+
+/**
+ * `throw()` aborts execution, so code after it is unreachable and a function whose
+ * body only throws needs no return statement.
+ *
+ * The binder previously treated only `error()` (FluffOS) / `raise_error()` (LDMud) as
+ * non-returning, on the stated grounds that "Fluff has throw too, but it doesn't
+ * terminate execution". That matches neither driver: FluffOS declares `void throw(mixed)`
+ * in core.spec and routes it through the same `[[noreturn]] throw_error()` as `error()`,
+ * and LDMud documents its own `throw` as "Abort execution".
+ *
+ * Not async-specific -- but it is felt most there, since throw_error() documents a value
+ * thrown inside an async body as becoming the rejection reason / acatch() result, making
+ * "await, then throw" the driver's own idiom for rejecting. Those cases belong with the
+ * async work; `async` is not a keyword here.
+ */
+
+function messages(source: string, driverType = lpc.LanguageVariant.FluffOS): string {
+    const { ls, fileName } = createTestLanguageService({ "test.c": source }, { driverType });
+    const program = ls.getProgram()!;
+    const file = program.getSourceFile(fileName)!;
+    return [...file.parseDiagnostics, ...program.getSemanticDiagnostics(file)]
+        .map(d => lpc.flattenDiagnosticMessageText(d.messageText, " "))
+        .join(" | ");
+}
+
+const MISSING_RETURN = "must return a value";
+
+describe("throw() terminates control flow", () => {
+    describe("FluffOS", () => {
+        it("does not require a return when the body only throws", () => {
+            expect(messages(`private int f() { throw("no"); }`)).toBe("");
+        });
+
+        it("treats throw() the same as error(), which already terminated", () => {
+            expect(messages(`private int f() { error("no"); }`)).toBe("");
+        });
+
+        it("still reports a genuinely missing return", () => {
+            expect(messages(`private int f() { }`)).toContain(MISSING_RETURN);
+        });
+
+        it("still reports a missing return when only one branch throws", () => {
+            // A non-constant condition: the fall-through is reachable and returns nothing.
+            expect(messages(`private int f(int x) { if(x) throw("no"); }`)).toContain(MISSING_RETURN);
+        });
+
+        it("accepts a branch that throws beside one that returns", () => {
+            expect(messages(`private int f(int x) { if(x) throw("no"); return 1; }`)).toBe("");
+        });
+    });
+
+    describe("LDMud", () => {
+        const LD = lpc.LanguageVariant.LDMud;
+
+        it("does not require a return when the body only throws", () => {
+            // LDMud's own efun declaration is `void throw(mixed arg)` -- "Abort execution".
+            expect(messages(`private int f() { throw("no"); }`, LD)).toBe("");
+        });
+
+        it("treats raise_error() as terminating, as before", () => {
+            expect(messages(`private int f() { raise_error("no"); }`, LD)).toBe("");
+        });
+
+        it("still reports a genuinely missing return", () => {
+            expect(messages(`private int f() { }`, LD)).toContain(MISSING_RETURN);
+        });
+    });
+
+    it("does not treat an unrelated call named like a terminator as terminating", () => {
+        // Only a bare identifier call counts; a member call named `throw` is someone
+        // else's function and says nothing about this function's control flow.
+        expect(messages(`private int f() { object o; o->throw("no"); }`)).toContain(MISSING_RETURN);
+    });
+});


### PR DESCRIPTION
## Summary

The binder treated only `error()` (FluffOS) / `raise_error()` (LDMud) as non-returning, excluding `throw()`:

```ts
// error() for Fluff
// raise_error() for LD
// Fluff has throw too, but it doesn't terminate execution.
```

That last line matches neither driver:

- **FluffOS** declares `void throw(mixed)` in `core.spec` and routes `f_throw()` through the same `[[noreturn]] throw_error()` (`simulate.cc`) that `error()` uses. A `catch()` resumes *after the catch*, never after the call.
- **LDMud** documents its own `void throw(mixed arg)` as "Abort execution" (mirrored in this repo at `efuns/ldmud/efun.h`).

So code after a `throw()` is unreachable, and a function whose body only throws needs no return statement.

## User-visible change

A non-void function whose body only throws no longer reports a spurious *"A function whose declared type is not 'void' must return a value"*:

```lpc
private int f() { throw("no"); }   // was: missing-return error;  now: clean
private int f() { error("no"); }   // unchanged: already clean
private int f() { }                // unchanged: still an error
```

`throw()` now counts under both drivers, so the LDMud case improves too.

## Notes

Not async-specific, but felt most there: `throw_error()` documents a value thrown inside an async body as becoming the rejection reason / `acatch()` result, which makes "await, then throw" the driver's own idiom for rejecting. A function written that way is currently forced to add an unreachable `return` to silence the diagnostic.

Only a bare identifier call counts, as before — `o->throw(...)` is someone else's function and says nothing about local control flow. There is a test for that.

## Tests

New `server/src/tests/throwTerminatesFlow.spec.ts` — 9 tests across both drivers: throw-only bodies, parity with `error()` / `raise_error()`, genuinely missing returns still caught, a reachable fall-through past a conditional throw still caught, and the member-call exclusion.

Full suite green — 1124 tests, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DGBDUhBwKX9rwp8bLCG9p