### PR TITLE
fix(checker): keep an array's declared element type when assigned a mixed

### DIFF
--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -30886,8 +30886,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     declaredType === objectType || 
                     declaredType === mixedType || 
                     isMappingType(declaredType) ||
-                    // see https://github.com/jlchmura/lpc-language-server/issues/190
-                    (isArrayType(declaredType) && declaredType.resolvedTypeArguments && !isAnonymousObjectType(first(declaredType.resolvedTypeArguments)))
+                    // see https://github.com/jlchmura/lpc-language-server/issues/190 -- a generic
+                    // `object*` narrows to the file-typed object array assigned into it. Only the
+                    // generic element type qualifies: an array that already states what it holds
+                    // (`string*`, `int*`) gains nothing here and can only be widened by it.
+                    (isArrayType(declaredType) && declaredType.resolvedTypeArguments?.length === 1 && first(declaredType.resolvedTypeArguments) === objectType)
                 ) {
                     // Whether the declaration states what the array holds. `mixed*` does not
                     // count: `mixed` is `any`, which says nothing about the contents.

--- a/server/src/tests/arrayDeclaredTypeRetention.spec.ts
+++ b/server/src/tests/arrayDeclaredTypeRetention.spec.ts
@@ -14,9 +14,27 @@ import { createTestLanguageService } from "./harness.js";
  * the variable widened past its own declaration from that point on.
  *
  * Scalars never had this problem: `int r = some_mixed()` stays `int`.
+ *
+ * That was first patched by guarding the one shape it was found in -- an assigned `mixed*`. The
+ * same hole then turned up for a bare `mixed`, which is not an array type and so walked past the
+ * guard:
+ *
+ *     string *candidates = reduce(path, fn, ({}));   // a simul_efun returning `mixed`
+ *     filter(candidates, (: ... :));                 // resolved on `mixed`, picking filter's
+ *                                                    // `string|mapping` overload over `mixed*`
+ *
+ * The cause was the branch's entry condition rather than either shape reaching it. #190 needs
+ * exactly one thing: a *generic* `object*` narrowing to the file-typed object array assigned into
+ * it, so `w->method()` resolves against the real file. The condition was written as "any array
+ * whose element is not already file-typed", which swept in `string*` and `int*` -- declarations
+ * that already state what they hold, gain nothing from adopting an assigned type, and can only be
+ * widened by it. Restricting the condition to a generic `object` element retires both guards'
+ * reason for existing: every other array now falls through to the ordinary path, where the
+ * declared type wins and assignment only narrows within it, which is why scalars were always
+ * immune.
  */
-function build(source: string) {
-    const { ls, abs } = createTestLanguageService({ "test.c": source }, {
+function build(source: string, extraFiles: Record<string, string> = {}) {
+    const { ls, abs } = createTestLanguageService({ "test.c": source, ...extraFiles }, {
         driverType: lpc.LanguageVariant.FluffOS,
         diagnostics: true,
     });
@@ -29,8 +47,8 @@ function hoverAt(source: string, marker: string): string | undefined {
         ?.displayParts?.map(p => p.text).join("").replace(/\s+/g, " ").trim();
 }
 
-function diagnosticsFor(source: string): string[] {
-    const { ls, file } = build(source);
+function diagnosticsFor(source: string, extraFiles?: Record<string, string>): string[] {
+    const { ls, file } = build(source, extraFiles);
     return ls.getSemanticDiagnostics(file).map(d => `${d.code}: ${lpc.flattenDiagnosticMessageText(d.messageText, " ")}`);
 }
 
@@ -49,6 +67,40 @@ describe("an array variable assigned a wider array type", () => {
         // lpc-language-server#190 -- the reason this branch exists. Only widening changed.
         const source = `test() {\n  object *w;\n  w = get_weaps();\n  w;\n}\nobject *get_weaps() { return ({ }); }\n`;
         expect(hoverAt(source, "w;\n}")).toBe("(local var) object* w");
+    });
+
+    it("keeps its declared type when the assigned type is a bare mixed", () => {
+        // `mixed*` was guarded first; `mixed` is not an array type and walked past that guard.
+        const source = `mixed g() { return ({}); }\ntest() {\n  string *r = g();\n  r;\n}\n`;
+        expect(hoverAt(source, "r;\n}")).toBe("(local var) string* r");
+    });
+
+    it("resolves a later call on the declared type, not on mixed", () => {
+        // The reported symptom: `filter` has a `string|mapping` overload declared before its
+        // `mixed*` one, so a source widened to `mixed` matched the wrong one and the result came
+        // back `string|mapping`.
+        const source = `mixed g() { return ({}); }\ntest() {\n  string *c = g();\n  string *r = filter(c, (: 1 :));\n}\n`;
+        expect(diagnosticsFor(source)).toEqual([]);
+    });
+
+    it("keeps checking the declared element type after such an assignment", () => {
+        // Widening did not just misreport the hover -- it retired every later check on the
+        // variable. This append was silently accepted.
+        const source = `mixed g() { return ({}); }\ntest() {\n  string *c = g();\n  c += ({ 123 });\n}\n`;
+        expect(diagnosticsFor(source).join(" "))
+            .toContain("2365: Operator '+=' cannot be applied to types 'string*' and 'int*'.");
+    });
+
+    it("narrows a generic object array to the file type assigned into it", () => {
+        // #190's actual case, and the only one the branch is now entered for: the element type
+        // has to reach the specific file for `->query_number()` to resolve. Asserted through
+        // diagnostics rather than hover, whose text carries an absolute path.
+        const source = `test() {\n  object *w;\n  w = get_weaps();\n  w->query_number();\n}\n`
+            + `/**\n * @returns {"object.c"*}\n */\nobject *get_weaps() { return ({ }); }\n`;
+        const files = { "object.c": `int query_number() { return 1; }\n` };
+        expect(diagnosticsFor(source, files)).toEqual([]);
+        expect(diagnosticsFor(source.replace("query_number()", "not_a_method()"), files).join(" "))
+            .toContain("2339: Property 'not_a_method' does not exist");
     });
 });
 


### PR DESCRIPTION
## The bug

An array variable declared with an element type is widened to whatever is assigned into it when that value is `mixed`, discarding its own declaration for every later reference.

```lpc
mixed g();
void p() {
  string *c = g();
  c;                                  // hover: mixed c  -- declaration discarded
  c += ({ 123 });                     // silently accepted
  string *r = filter(c, (: 1 :));     // 2322: Type 'string | mapping' is not assignable to type 'string*'
}
```

Found in the wild via a simul_efun declared `varargs mixed reduce(mixed *arr, function fun, mixed init, mixed arg...)`:

```lpc
string *candidates = reduce(path, function(string *acc, string curr, int idx, string *arr) { ... }, ({}));
string *can_improve = filter(candidates, (: query_raw_skill($1) < $(skill_cap) :));
```

Two things follow from the widening. The variable stops being checked at all — the `+=` above is a real mismatch that goes unreported. And overload resolution changes: `filter` in `efuns/fluffos/general.h` declares its `string|mapping` overload (L382) before its `mixed*` one (L402), so a `mixed` source matches the first and returns `string|mapping`. The diagnostic then lands on the assignment target, two lines below the line that actually caused it, which makes it fairly opaque to read.

## Cause

Not the shape reaching the branch — the branch's entry condition in `getTypeAtFlowAssignment`.

#190 needs one thing: a generic `object*` narrowing to the file-typed object array assigned into it, so `w->query_number()` resolves against the real file (`flowType3.c`). The condition was written as *any array whose element is not already file-typed*:

```ts
(isArrayType(declaredType) && declaredType.resolvedTypeArguments && !isAnonymousObjectType(first(declaredType.resolvedTypeArguments)))
```

That sweeps in `string*` and `int*` — declarations that already state what they hold, gain nothing from adopting an assigned type, and can only be widened by it.

This has surfaced once before. `arrayDeclaredTypeRetention.spec.ts` documents the same bug in its `mixed*` → `int*` form, fixed by guarding that shape inside the branch. A bare `mixed` is not an array type, so it walks past that guard.

## Fix

Restrict the condition to a generic `object` element — what #190 actually needed:

```ts
(isArrayType(declaredType) && declaredType.resolvedTypeArguments?.length === 1 && first(declaredType.resolvedTypeArguments) === objectType)
```

Every other array now falls through to the ordinary path, where the declared type wins and assignment only narrows within it. That is exactly why scalars were always immune — `int r = some_mixed()` has always stayed `int` — so this makes arrays behave the way scalars already did. It also retires the earlier guard's reason for existing, though the guard is left in place since it still covers `object*`.

## Verification

| | before | after |
|---|---|---|
| `string *c = g()` (g returns `mixed`), at use | `mixed` | `string*` |
| `string *r = filter(c, ...)` | `2322` | clean |
| `string *c = g(); c += ({ 123 })` | **silently accepted** | `2365` |
| #190 `weapons->query_number()` (`flowType3.c` + `object.c`) | clean, file-typed | clean, file-typed |
| `mixed*` → `int*` (the earlier regression) | `int*` | `int*` |
| `mixed *x = ({}); x += ({ 1 })` | clean | clean |
| `int n = some_mixed()` | `int` | `int` |

Four tests added to `arrayDeclaredTypeRetention.spec.ts`, alongside the `mixed*` form of the same bug. The three bug tests fail without the checker change and pass with it; the fourth pins #190's file-typed narrowing, which is the behaviour the narrowed condition has to keep, and passes either way.

Full suite: 1127 tests, 35 suites, 293 snapshots, all passing. `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjbfqK6x9uaRfM95QKtF8g