### PR TITLE
fix(parser): scan templates as templates inside a disabled region

### DIFF
--- a/server/src/compiler/parser.ts
+++ b/server/src/compiler/parser.ts
@@ -718,6 +718,15 @@ export namespace LpcParser {
         // Drive preprocessor conditionals and skip over disabled regions. A conditional
         // directive is always processed (nesting must be tracked even while inactive);
         // any other token inside a disabled region is discarded.
+        //
+        // A template still has to be *scanned* as a template while it is being discarded.
+        // In executable code the parser drives the continuation, re-scanning the `}` that
+        // ends each substitution (see parseTemplateSpan); nothing drives it here. Left to
+        // plain scanning, that `}` comes back as a close brace and the closing backtick
+        // opens a fresh template head that runs to end of file -- swallowing the `#endif`
+        // and reporting an unterminated string plus an unmatched conditional directive.
+        let templateBraceDepths: number[] | undefined;
+        let braceDepth = 0;
         while (incomingToken !== SyntaxKind.EndOfFileToken) {
             if (isConditionalDirective(incomingToken)) {
                 processConditionalDirective(incomingToken);
@@ -725,6 +734,34 @@ export namespace LpcParser {
                 continue;
             }
             if (isCodeExecutable === Ternary.False) {
+                switch (incomingToken) {
+                    case SyntaxKind.TemplateHead:
+                    case SyntaxKind.TemplateMiddle:
+                        // The `${` is part of the token, so the substitution's expression
+                        // begins at the depth we are already at.
+                        (templateBraceDepths ??= []).push(braceDepth);
+                        break;
+                    case SyntaxKind.OpenBraceToken:
+                    // `({` is a single token, but it closes with a plain `}` followed by
+                    // `)`. Without counting it, an array literal inside a substitution
+                    // would look like the brace that ends the substitution.
+                    case SyntaxKind.OpenParenBraceToken:
+                        braceDepth++;
+                        break;
+                    case SyntaxKind.CloseBraceToken:
+                        if (templateBraceDepths?.length && last(templateBraceDepths) === braceDepth) {
+                            templateBraceDepths.pop();
+                            // Re-scanning yields TemplateMiddle (another substitution
+                            // follows) or TemplateTail (the literal ends). Loop around so
+                            // the result is classified like any other discarded token.
+                            incomingToken = scanner.reScanTemplateToken(/*isTaggedTemplate*/ false);
+                            continue;
+                        }
+                        if (braceDepth > 0) {
+                            braceDepth--;
+                        }
+                        break;
+                }
                 incomingToken = scanner.scan();
                 continue;
             }

--- a/server/src/tests/templateLiterals.spec.ts
+++ b/server/src/tests/templateLiterals.spec.ts
@@ -120,6 +120,60 @@ describe("Template literals", () => {
         });
     });
 
+    describe("inside an inactive preprocessor region", () => {
+        /**
+         * A template in disabled code still has to be *scanned* as a template even though
+         * every token is thrown away. In executable code the parser drives the continuation,
+         * re-scanning the `}` that ends each substitution (parseTemplateSpan); the skip loop
+         * that discards disabled tokens had nothing driving it. The `}` came back as a plain
+         * close brace, so the closing backtick opened a fresh template head that ran to end
+         * of file -- swallowing the `#endif` and cascading into unrelated-looking errors
+         * (unmatched conditional, unterminated string, "invalid character" on each `\` in
+         * the swallowed region, and bogus checker errors from the wrecked parse).
+         *
+         * A backtick with no interpolation was never affected: it scans as a single
+         * NoSubstitutionTemplateLiteral, so there is no `}` to re-scan.
+         */
+        it("does not run past the #endif", () => {
+            const sf = parse("void f() {\n  int x = 1;\n#if 0\n  y(`val ${x}`);\n#endif\n}");
+            expect(sf.parseDiagnostics.length).toBe(0);
+        });
+
+        it("was already fine without interpolation, and still is", () => {
+            expect(parse("void f() {\n#if 0\n  y(`val`);\n#endif\n}").parseDiagnostics.length).toBe(0);
+            expect(parse('void f() {\n#if 0\n  y("val\\n");\n#endif\n}').parseDiagnostics.length).toBe(0);
+        });
+
+        it("handles several substitutions and nested templates", () => {
+            expect(parse("void f() {\n#if 0\n  y(`a${x}b${x}c`);\n#endif\n}").parseDiagnostics.length).toBe(0);
+            expect(parse("void f() {\n#if 0\n  y(`a${ `i${x}` }b`);\n#endif\n}").parseDiagnostics.length).toBe(0);
+        });
+
+        it("counts `({` so an array literal's brace is not read as the substitution's", () => {
+            // `({` is a single token but closes with a plain `}` followed by `)`. Left
+            // uncounted, that `}` matches the substitution's depth and ends the template early.
+            expect(parse("void f() {\n#if 0\n  y(`a${ ({1,2})[0] }b`);\n#endif\n}").parseDiagnostics.length).toBe(0);
+            expect(parse("void f() {\n#if 0\n  { y(`a${x}b`); }\n#endif\n}").parseDiagnostics.length).toBe(0);
+        });
+
+        it("leaves the region's own escapes alone", () => {
+            expect(parse("void f() {\n#if 0\n  y(`a${x}\\n`);\n#endif\n}").parseDiagnostics.some(d => d.code === 1127)).toBe(false);
+        });
+
+        it("still sees the directives that follow", () => {
+            expect(parse("void f() {\n#if 0\n  y(`a${x}`);\n#else\n  x = 2;\n#endif\n}").parseDiagnostics.length).toBe(0);
+            expect(parse("void f() {\n#if 0\n  y(`a${x}`);\n#if 1\n  x = 1;\n#endif\n#endif\n}").parseDiagnostics.length).toBe(0);
+        });
+
+        it("reports a genuinely unterminated template the same way a plain string is", () => {
+            // Unchanged behaviour: malformed literals in disabled code still report, and a
+            // template now matches what an unterminated `"` there has always done.
+            const tmpl = parse("void f() {\n#if 0\n  y(`a${x});\n#endif\n}").parseDiagnostics.map(d => d.code).sort();
+            const str = parse('void f() {\n#if 0\n  y("abc);\n#endif\n}').parseDiagnostics.map(d => d.code).sort();
+            expect(tmpl).toEqual(str);
+        });
+    });
+
     describe("adjacency concatenation (FluffOS allows, JavaScript does not)", () => {
         function assertConcatenates(source: string) {
             const sf = parse(source);


### PR DESCRIPTION
## The bug

A `${...}` interpolation inside an inactive preprocessor region makes the scanner run off the end of the file.

```lpc
void f() {
  int x = 1;
#if 0
  tell(this_object(), `val ${x}`);
#endif
}
```

```
9013: Unmatched conditional directive.
1002: Unterminated string literal.
```

A backtick with no interpolation inside `#if 0` is fine. A `"...\n"` string inside `#if 0` is fine. `` `val ${x}` `` outside `#if 0` is fine. It is specifically interpolation in a disabled region.

## Cause

A template has to be *scanned* as a template even when every token is being thrown away.

In executable code the parser drives the continuation, re-scanning the `}` that ends each substitution (`parseTemplateSpan` → `scanner.reScanTemplateToken`). The loop in `nextTokenWithoutCheck` that discards tokens in a disabled region had nothing driving it, so the `}` came back as a plain `CloseBraceToken` and the closing backtick opened a fresh template head that ran to end of file.

That swallows the `#endif` — hence the unmatched conditional — and everything after it becomes literal text, so each `\` in the swallowed region is reported as an invalid character, and the checker then works on a wrecked parse.

## Fix

The skip loop tracks brace depth and re-scans a substitution's closing `}` as a template continuation, mirroring what the parser does.

`({` is counted alongside `{`. It is a single token (`OpenParenBraceToken`) but closes with a plain `}` followed by `)`, so without counting it an array literal inside a substitution — `` `${ ({1,2})[0] }` `` — would have its brace mistaken for the one that ends the substitution. There is a test pinning that case.

## Found on

A mudlib file reporting 14 diagnostics from six `#if 0` debug blocks. Running the real file's contents through the harness, fix off vs. on:

| code | before | after |
|---|---|---|
| 9013 unmatched conditional | 1 | 0 |
| 1002 unterminated string | 1 | 0 |
| 1127 invalid character | 5 | 0 |
| 1351 | 4 | 0 |
| 8024 LPCDoc `@param` with empty name | 1 | 0 |
| 2339 property missing on `object` | 1 | 0 |

The last two sat *above* the first `#if 0` block and looked unrelated; both were parse-recovery collateral.

## One deliberate behaviour change

An **unterminated** template with interpolation in a disabled region now reports, where it used to be silent. That silence was the same bug — the head ended at `${` and nothing re-entered template mode, so no unterminated literal was ever detected. It now agrees with the two forms that were never affected:

```
unterminated `a${x}  in #if 0  ->  1002 + 9013   (was silent)
unterminated "abc    in #if 0  ->  1002 + 9013
unterminated `abc    in #if 0  ->  1002 + 9013
```

## Tests

7 added to `templateLiterals.spec.ts` under a new `inside an inactive preprocessor region` block: multiple substitutions, nested templates, the `({` case, escapes, `#else` and nested `#if` following the template, and the unterminated-parity case. 6 fail without the parser change; the no-interpolation control passes either way.

Full suite: 1130 tests, 35 suites, 293 snapshots, all passing. `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjbfqK6x9uaRfM95QKtF8g