### PR TITLE
fix(efuns): filter() returns the source's own type, not a union

### DIFF
--- a/efuns/fluffos/general.h
+++ b/efuns/fluffos/general.h
@@ -337,14 +337,11 @@ float * id_matrix();
  * If the first syntax is used, the filter function is performed as a
  * call_other. If ob is a string, it is assumed to be the filename of an
  * object to load and call the filter function on.
- * @template {string|mapping|mixed*} T
- * @param {T} source - The source to filter
- * @returns {T} - The filtered source
+ * @param source - The source to filter
  */
-mixed filter(string|mapping|mixed* source,
-             string filter_function,
-             object|string ob,
-             mixed *extra...);
+varargs mapping filter( mapping source, string filter_function, object|string ob, mixed *extra... );
+varargs string  filter( string  source, string filter_function, object|string ob, mixed *extra... );
+varargs mixed*  filter( mixed*  source, string filter_function, object|string ob, mixed *extra... );
 
 /**
  * @template T
@@ -374,11 +371,8 @@ mixed filter(string|mapping|mixed* source,
  * If the first syntax is used, the filter function is performed as a
  * call_other. If ob is a string, it is assumed to be the filename of an
  * object to load and call the filter function on.   
- * @template {string|mapping} T - string, mapping, or array
- * @param {T} source - The source to filter
- * @returns {T} - The filtered source
- */             
-string|mapping filter(string|mapping source, function f, mixed *extra... );
+ * @param source - The source to filter
+ */
 
 /**
  * filter
@@ -400,8 +394,10 @@ string|mapping filter(string|mapping source, function f, mixed *extra... );
  * @param {T*} source - The source array to filter
  * @param {filterCallback<T>} f - The filter function
  * @returns {T*} - The filtered array
- */       
-mixed* filter(mixed* source, function f, mixed *extra... );
+ */
+varargs mixed* filter( mixed* source, function f, mixed extra... );
+varargs mapping filter( mapping source, function f, mixed extra... );
+varargs string  filter( string  source, function f, mixed extra... );
 
 /**
  * explode_reversible


### PR DESCRIPTION
`filter()` was declared with a union parameter plus a generic constrained to that same union:

```c
/** @template {string|mapping} T
 *  @param {T} source
 *  @returns {T} */
string|mapping filter(string|mapping source, function f, mixed *extra... );
```

`T` never resolved against a concrete argument, so the call returned `unknown`. That affected a string source, a mapping source and a `mixed` one alike — only a genuine array escaped, by landing on the separate `mixed*` overload.

`map()` directly above it already had the shape that works: one concrete overload per source type, no union parameter, and the generic machinery on the array form alone. This makes `filter()` match.

Measured with the CLI against a 610-file FluffOS mudlib:

| source | `map` | `filter` before | `filter` after |
|---|---|---|---|
| `string*` | `string*` | `string*` | `string*` |
| `string` | `string` | `unknown` | `string` |
| `mapping` | `mapping` | `unknown` | `mapping` |
| `mixed` | `mixed*` | `unknown` | `mixed*` |

Two notes on the shape, since neither is arbitrary:

- **The array form leads.** A `mixed` source matches the first candidate it can, so the leading overload decides what it gets. With the array form first it resolves to `mixed*`, which is the useful default and the same answer `map()` gives.
- **The generics stay on the array form only.** That is what carries the element type through — `string*` in, `string*` out. Dropping it degrades the array case to `mixed*`.

Whole-lib error count goes from 38 in 17 files to 33 in 13. Full suite passes (53 suites, 1324 tests).

The 3-argument `call_other` form got the same concrete-overload split for consistency, but my testing only exercised the functional form — that ordering is unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqnJwvSWxi8m8gqJX4dYu8