### PR TITLE
A call-other on an array of objects returns an array

### DIFF
--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -16446,6 +16446,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         //     }
         // }
 
+        // `arr->func()` yields one return per element, so lift the signature's return type
+        // into an array. Skipped for mixed/void/error returns: mixed already accepts an
+        // array, and neither driver produces a `void*`.
+        if (
+            isCallExpression(node) &&
+            isPropertyAccessExpression(node.expression) && getNodeLinks(node.expression).calledOnArray &&
+            !(returnType.flags & (TypeFlags.Any | TypeFlags.Void | TypeFlags.Never)) && !isErrorType(returnType)
+        ) {
+            return createArrayType(returnType);
+        }
+
         return returnType;
     }
     
@@ -25724,9 +25735,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function checkPropertyAccessExpressionOrQualifiedName(node: PropertyAccessExpression | QualifiedName, left: Expression | QualifiedName, leftType: Type, right: Identifier | ParenthesizedExpression, checkMode: CheckMode | undefined, writeOnly?: boolean) {
         const parentSymbol = getNodeLinks(left).resolvedSymbol;
         const assignmentKind = getAssignmentTargetKind(node);
-        // if left is an array, then use its element type in fluffos
-        const origLeftType = leftType;        
-        leftType = languageVariant===LanguageVariant.FluffOS && isArrayType(leftType) ? getElementTypeOfArrayType(leftType) : leftType;
+        // `arr->func()` calls func on every element and hands back an array of the returns.
+        // Both drivers do this -- FluffOS documents it under call_other() (calls.h), LDMud
+        // under call_other(E) -- so record it for either, and checkCallExpression wraps the
+        // call's result back up. Without the mark a call types as a bare element return.
+        const calledOnArray = isArrayType(leftType);
+        getNodeLinks(node).calledOnArray = calledOnArray;
+        // Resolving the member against the element type is FluffOS-only, and only affects
+        // which type the lookup and its errors are phrased against: getPropertyOfType peels
+        // an object array itself, which is how the LDMud path finds the member regardless.
+        leftType = calledOnArray && languageVariant === LanguageVariant.FluffOS ? getElementTypeOfArrayType(leftType) : leftType;
         const apparentType = getApparentType(assignmentKind !== AssignmentKind.None || isMethodAccessForCall(node) ? getWidenedType(leftType) : leftType);
         const isAnyLike = isTypeAny(apparentType) || apparentType === silentNeverType;
         let prop: Symbol | undefined;       

--- a/server/src/compiler/types.ts
+++ b/server/src/compiler/types.ts
@@ -4981,6 +4981,7 @@ export interface NodeLinks {
     parameterInitializerContainsUndefined?: boolean; // True if this is a parameter declaration whose type annotation contains "undefined".
     fakeScopeForSignatureDeclaration?: "params" | "typeParams"; // If present, this is a fake scope injected into an enclosing declaration chain.
     assertionExpressionType?: Type;     // Cached type of the expression of a type assertion
+    calledOnArray?: boolean;            // FluffOS: `->` whose base was an array, so the call yields an array of returns
     potentialThisCollisions?: Node[];
     potentialNewTargetCollisions?: Node[];
     potentialWeakMapSetCollisions?: Node[];

--- a/server/src/tests/arrayCallOtherReturn.spec.ts
+++ b/server/src/tests/arrayCallOtherReturn.spec.ts
@@ -1,0 +1,92 @@
+import * as lpc from "./_namespaces/lpc.js";
+import { createTestLanguageService } from "./harness.js";
+
+/**
+ * `arr->func()` against an array of objects calls func on every element and hands back an
+ * array of the returns. Both drivers do this. FluffOS, under call_other(): "If the first
+ * argument is an array instead of an object, then the call will be done in all elements of
+ * that array ..., and an array of returns will be returned." LDMud, under call_other(E):
+ * "the function is called with the same arguments in all the given objects. The single
+ * results are collected in an array and yield the final result" -- whose own example is
+ * `string *s; s = (string *)users()->short();`. Non-optional there since LDMud 3.5.0.
+ *
+ * The checker resolved the member against the array's *element* type so the lookup would
+ * succeed, but nothing put the array back afterwards, so the call typed as a single element's
+ * return. That reads as a false negative on its own:
+ *
+ *     string name = livings()->query_name();     // accepted; it is a string*
+ *
+ * and turns into a spurious error once the result is passed on, because a generic parameter
+ * infers from it:
+ *
+ *     sort_array(who->query_name(), 1)           // T inferred as `string`, so `arr` wanted
+ *                                                // `string*` and the argument "did not match"
+ *
+ * A mixed return is left alone: `mixed` already accepts an array, and it is also what the
+ * checker hands back for the shapes it does not model (an optional `?->` chain, say), which
+ * should not be turned into `mixed*`.
+ */
+function diagnosticsFor(driver: lpc.LanguageVariant, source: string, extraFiles: Record<string, string> = {}): string[] {
+    const { ls, abs } = createTestLanguageService({ "test.c": source, ...extraFiles }, {
+        driverType: driver,
+        diagnostics: true,
+    });
+    return ls.getSemanticDiagnostics(abs("test.c"))
+        .map(d => `${d.code}: ${lpc.flattenDiagnosticMessageText(d.messageText, " ")}`);
+}
+
+const body = {
+    "body.c": `string query_name() { return "bob"; }\nint query_level() { return 1; }\nvoid quit() {}\nmixed query_stuff() { return 0; }\n`,
+};
+
+/** Runs `stmt` with `who` an array of body.c objects and `one` a single one. */
+function call(driver: lpc.LanguageVariant, stmt: string): string[] {
+    return diagnosticsFor(
+        driver,
+        `/** @type {"body.c"*} */ object *who;\n`
+        + `/** @type {"body.c"} */ object one;\n`
+        + `test() {\n  ${stmt}\n}\n`,
+        body,
+    );
+}
+
+describe.each([
+    ["FluffOS", lpc.LanguageVariant.FluffOS],
+    ["LDMud", lpc.LanguageVariant.LDMud],
+] as const)("a call-other against an array of objects (%s)", (_name, driver) => {
+    it("returns an array of the element returns", () => {
+        expect(call(driver, `string *names = who->query_name();`)).toEqual([]);
+        expect(call(driver, `int *levels = who->query_level();`)).toEqual([]);
+    });
+
+    it("reports assigning that array to a scalar", () => {
+        expect(call(driver, `string name = who->query_name();`).join(" "))
+            .toContain("2322: Type 'string*' is not assignable to type 'string'.");
+    });
+
+    it("leaves a call against a single object scalar", () => {
+        expect(call(driver, `string name = one->query_name();`)).toEqual([]);
+        expect(call(driver, `string *names = one->query_name();`).join(" "))
+            .toContain("2322: Type 'string' is not assignable to type 'string*'.");
+    });
+
+    it("leaves a void return alone", () => {
+        // The driver produces no `void*`, and the result is discarded anyway.
+        expect(call(driver, `who->quit();`)).toEqual([]);
+    });
+
+    it("leaves a mixed return alone", () => {
+        // mixed already accepts an array, and it doubles as the checker's "not modelled" type.
+        expect(call(driver, `string stuff = who->query_stuff();`)).toEqual([]);
+    });
+});
+
+describe("a generic efun parameter", () => {
+    it("infers from the array a call-other produced, not from its element", () => {
+        // The reported symptom. FluffOS's sort_array is `@template T` / `@param {T*} arr`, so
+        // an element return made T a scalar and the argument then fit no overload. LDMud's
+        // sort_array is not generic and has no `(arr, direction)` form, so it has nothing to
+        // say here -- the behaviour under test is the argument's type, covered for both above.
+        expect(call(lpc.LanguageVariant.FluffOS, `string *sorted = sort_array(who->query_name(), 1);`)).toEqual([]);
+    });
+});


### PR DESCRIPTION
`arr->func()` calls func on every element and collects the returns into an array. Both drivers do this — FluffOS documents it under `call_other()`, LDMud under `call_other(E)`, whose own example is `string *s = (string *)users()->short();`.

The member was resolved against the array's element type so the lookup would succeed, but nothing put the array back, so the call typed as one element's return. On its own that reads as a false negative:

```lpc
string name = livings()->query_name();   // accepted; it is a string*
```

and it becomes a spurious error as soon as the result reaches a generic parameter, which then infers from the wrong type:

```lpc
sort_array(who->query_name(), 1)
// No overload matches this call.
//   Overload 1 of 3, '(string* arr, function f, mixed extra...)', gave the following error.
//     Argument of type 'string' is not assignable to parameter of type 'string*'.
```

`sort_array` is `@template T` / `@param {T*} arr`, so T came back as `string` and no overload could fit.

The fix records the array base on the property access and lifts the return type at the call. `mixed`, `void` and error returns are left alone: `mixed` already accepts an array and doubles as the checker's "not modelled" type (an optional `?->` chain yields it deliberately), and neither driver produces a `void*`.

Not gated on FluffOS. `getPropertyOfType` peels an object array's element type for every driver, so the existing gate in `checkPropertyAccessExpressionOrQualifiedName` never controlled whether the member resolved — only which type the lookup and its errors are phrased against — and LDMud reached the same bug down its own path. The new spec runs over both variants.

Checked against a ~610-file FluffOS mudlib: one spurious error removed, none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183LNLuVrwEsAmuhjLSPzFX