### PR TITLE
Apply a @type annotation on a foreach loop variable

### DIFF
--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -24637,11 +24637,31 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return isTypeAssertion(node) ? type : getWidenedLiteralLikeTypeForContextualType(type, instantiateContextualType(getContextualType(node, /*contextFlags*/ undefined), node, /*contextFlags*/ undefined));
     }
 
+    /**
+     * A synthetic union or intersection property with more than two constituents records them
+     * instead of combining them (see getUnionOrIntersectionProperty), since most such symbols
+     * are never asked for a type and normalizing eagerly can explode. Combine on first demand.
+     *
+     * Without this, any property access on a union of three or more object types reached the
+     * `Debug.fail` this replaces -- `/** @type {A | B | C} object ob; ob->shared_method();`
+     * crashed the whole check. Two constituents never did, because that path computes eagerly.
+     */
+    function getTypeOfSymbolWithDeferredType(symbol: Symbol): Type {
+        const links = getSymbolLinks(symbol);
+        if (!links.type) {
+            Debug.assertIsDefined(links.deferralParent);
+            Debug.assertIsDefined(links.deferralConstituents);
+            links.type = links.deferralParent.flags & TypeFlags.Union
+                ? getUnionType(links.deferralConstituents)
+                : getIntersectionType(links.deferralConstituents);
+        }
+        return links.type;
+    }
+
     function getTypeOfSymbol(symbol: Symbol, checkMode?: CheckMode): Type {        
         const checkFlags = getCheckFlags(symbol);
         if (checkFlags & CheckFlags.DeferredType) {
-            Debug.fail("TODO - getTypeOfSymbol");
-            // return getTypeOfSymbolWithDeferredType(symbol);
+            return getTypeOfSymbolWithDeferredType(symbol);
         }
         if (checkFlags & CheckFlags.Instantiated) {
             return getTypeOfInstantiatedSymbol(symbol);

--- a/server/src/compiler/checker.ts
+++ b/server/src/compiler/checker.ts
@@ -9724,6 +9724,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         checkMode: CheckMode,
     ): Type | undefined {        
         if (isVariableDeclaration(declaration) && declaration.parent.parent.kind === SyntaxKind.ForEachStatement) {
+            // An explicit `@type` on the loop variable wins, the same as it would on a plain
+            // declaration. Without this the element type below is returned unconditionally and
+            // the annotation is silently discarded -- `foreach(/** @type {"/a"} */ object ob in
+            // stuff())` left `ob` as a bare `object`, so every `ob->method()` failed to resolve.
+            // Only a real JSDoc type counts: the declarator's own `object`/`mixed` keyword must
+            // still lose to the element type, which is what narrows the loop variable at all.
+            if (getJSDocType(declaration)) {
+                const annotated = tryGetTypeFromEffectiveTypeNode(declaration);
+                if (annotated) return annotated;
+            }
+
             const forEach = declaration.parent.parent;
             const expressionType = getNonNullableTypeIfNeeded(checkExpression(forEach.expression, checkMode));
 

--- a/server/src/tests/foreachTypeAnnotation.spec.ts
+++ b/server/src/tests/foreachTypeAnnotation.spec.ts
@@ -1,0 +1,90 @@
+import * as lpc from "./_namespaces/lpc.js";
+import { createTestLanguageService } from "./harness.js";
+
+/**
+ * Two fixes that have to land together: annotating a foreach loop variable did nothing, and
+ * making it work immediately reached a crash that was already there.
+ *
+ * 1. `getTypeForVariableLikeDeclaration` derived a foreach variable's type from the iterated
+ *    expression and returned before ever consulting the declaration's own annotation, so
+ *    `foreach(/** @type {"/a"} * / object ob in stuff())` left `ob` a bare `object` and every
+ *    `ob->method()` failed to resolve. The same annotation on a plain declaration worked, which
+ *    is what made it look like an annotation problem rather than a foreach one.
+ *
+ * 2. A synthetic union property with MORE THAN TWO constituents records its constituents
+ *    instead of combining them, and the consumer for that (`getTypeOfSymbolWithDeferredType`)
+ *    was never ported -- `getTypeOfSymbol` hit a `Debug.fail` instead. So a property access on a
+ *    union of three or more object types crashed the whole check. Two constituents never did:
+ *    that path computes eagerly. Reachable today through a plain declaration, which is why it
+ *    is fixed on its own terms; fixing (1) is what made a real mudlib file reach it.
+ */
+function diagnosticsFor(source: string, extraFiles: Record<string, string> = {}): string[] {
+    const { ls, abs } = createTestLanguageService({ "test.c": source, ...extraFiles }, {
+        driverType: lpc.LanguageVariant.FluffOS,
+        diagnostics: true,
+    });
+    return ls.getSemanticDiagnostics(abs("test.c"))
+        .map(d => `${d.code}: ${lpc.flattenDiagnosticMessageText(d.messageText, " ")}`);
+}
+
+const files = {
+    "a.c": `int is_a() { return 1; }\nstring shared() { return "a"; }\n`,
+    "b.c": `int is_b() { return 1; }\nstring shared() { return "b"; }\n`,
+    "c.c": `int is_c() { return 1; }\nstring shared() { return "c"; }\n`,
+};
+
+/** `stmt` runs in a function body; `stuff()` is an untyped `object*`. */
+function check(stmt: string): string[] {
+    return diagnosticsFor(`object *stuff();\ntest() {\n  ${stmt}\n}\n`, files);
+}
+
+describe("a @type annotation on a foreach loop variable", () => {
+    it("is applied to the loop variable", () => {
+        expect(check(`foreach(/** @type {"a.c"} */ object ob in stuff())\n    ob->is_a();`)).toEqual([]);
+    });
+
+    it("still type-checks against the annotated type", () => {
+        // Applying the annotation must not mean trusting it blindly.
+        expect(check(`foreach(/** @type {"a.c"} */ object ob in stuff())\n    ob->nope();`).join(" "))
+            .toContain("2339: Property 'nope' does not exist on type 'object");
+    });
+
+    it("leaves an unannotated loop variable narrowing from the array", () => {
+        // The declarator's own `object` keyword must still lose to the element type -- that is
+        // what narrows a loop variable at all, and the fix must not cost it.
+        const source = `object *stuff();\ntest() {\n`
+            + `  /** @type {"a.c"*} */ object *arr = stuff();\n`
+            + `  foreach(object ob in arr)\n    ob->is_a();\n}\n`;
+        expect(diagnosticsFor(source, files)).toEqual([]);
+
+        expect(diagnosticsFor(source.replace("ob->is_a()", "ob->nope()"), files).join(" "))
+            .toContain("2339: Property 'nope' does not exist on type 'object");
+    });
+
+    it("carries a union annotation through, still checking every constituent", () => {
+        expect(check(`foreach(/** @type {"a.c" | "b.c"} */ object ob in stuff())\n    ob->is_a();`).join(" "))
+            .toContain("2339: Property 'is_a' does not exist on type");
+    });
+});
+
+describe("a property access on a union of more than two object types", () => {
+    it("resolves instead of crashing the check", () => {
+        // Three constituents defer; the deferral had no consumer and hit a Debug.fail.
+        expect(check(`/** @type {"a.c" | "b.c" | "c.c"} */ object ob = stuff()[0];\n  ob->shared();`))
+            .toEqual([]);
+    });
+
+    it("resolves the same way through a foreach annotation", () => {
+        expect(check(`foreach(/** @type {"a.c" | "b.c" | "c.c"} */ object ob in stuff())\n    ob->shared();`))
+            .toEqual([]);
+    });
+
+    it("still reports a property missing from one constituent", () => {
+        expect(check(`/** @type {"a.c" | "b.c" | "c.c"} */ object ob = stuff()[0];\n  ob->is_a();`).join(" "))
+            .toContain("2339: Property 'is_a' does not exist on type");
+    });
+
+    it("behaves the same at two constituents, which always computed eagerly", () => {
+        expect(check(`/** @type {"a.c" | "b.c"} */ object ob = stuff()[0];\n  ob->shared();`)).toEqual([]);
+    });
+});


### PR DESCRIPTION
Two commits. The first is a prerequisite for the second and stands on its own.

### Resolve a property on a union of more than two types

A synthetic union/intersection property with more than two constituents records them rather than combining them — normalizing eagerly can explode, and most such symbols are never asked for a type. `getUnionOrIntersectionProperty` already sets that up, but its consumer, `getTypeOfSymbolWithDeferredType`, was never ported; `getTypeOfSymbol` hit `Debug.fail("TODO")` instead.

So a property access on a union of three or more object types crashed the check outright, taking the rest of the project's diagnostics with it:

```lpc
/** @type {A | B | C} */ object ob;
ob->shared_method();       // Debug Failure. TODO - getTypeOfSymbol
```

Two constituents never did — that path computes eagerly — which is why it went unnoticed.

### Apply a @type annotation on a foreach loop variable

`getTypeForVariableLikeDeclaration` derived a foreach variable's type from the iterated expression and returned before consulting the declaration's own annotation, so the annotation was silently discarded:

```lpc
foreach(/** @type {"/a"} */ object ob in stuff())
    ob->method();          // Property 'method' does not exist on type 'object'
```

The same annotation on a plain declaration worked, which made it look like an annotation problem rather than a foreach one.

The annotation is taken only when there is an explicit JSDoc `@type`; otherwise the existing path runs unchanged, so the declarator's own `object`/`mixed` keyword still loses to the element type. That fallthrough is what narrows an unannotated loop variable, and it keeps working.

The two land together because a real mudlib file annotates a loop variable with a three-type union — nothing reached the crash before the second commit.

Checked against a ~610-file FluffOS mudlib: five spurious errors removed, none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183LNLuVrwEsAmuhjLSPzFX